### PR TITLE
Fix connection reset by peer when ssl context check_hostname is false and certificate verification is none

### DIFF
--- a/agent/exploits/cve_2023_48788.py
+++ b/agent/exploits/cve_2023_48788.py
@@ -43,6 +43,11 @@ MAX_REDIRECTS = 2
 FORTIGATE_SIGNATURE = "FortiClient Endpoint Management Server"
 
 
+context = ssl.create_default_context()
+context.check_hostname = False
+context.verify_mode = ssl.CERT_NONE
+
+
 @exploits_registry.register
 class CVE202348788Exploit(definitions.Exploit):
     """
@@ -68,12 +73,16 @@ class CVE202348788Exploit(definitions.Exploit):
         msg_len = len(REGISTER + PAYLOAD)
         msg = REGISTER.format(PAYLOAD, msg_len)
 
-        addr = (target.host, int(target.port))
-        socker_wrapper = self._get_socket_wrapper(target.host)
-        socker_wrapper.connect(addr)
-        socker_wrapper.send(msg.encode())
+        socket_wrapper = self._get_socket_wrapper((target.host, target.port))
+        if socket_wrapper is None:
+            return vulnerabilities
+        socket_wrapper.send(msg.encode())
 
-        response = socker_wrapper.recv(1024)
+        try:
+            response = socket_wrapper.read(2047)
+        except socket.error:
+            return vulnerabilities
+
         if response is not None and "KA_INTERVAL" in response.decode():
             vulnerability = self._create_vulnerability(target)
             vulnerabilities.append(vulnerability)
@@ -113,11 +122,10 @@ class CVE202348788Exploit(definitions.Exploit):
         )
         return vulnerability
 
-    def _get_socket_wrapper(self, host: str) -> ssl.SSLSocket:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(DEFAULT_TIMEOUT)
-        context = ssl.create_default_context()
-        context.check_hostname = False
-        context.verify_mode = ssl.CERT_NONE
-        socker_wrapper = context.wrap_socket(s, server_hostname=host)
-        return socker_wrapper
+    def _get_socket_wrapper(self, host: tuple[str, int]) -> ssl.SSLSocket | None:
+        try:
+            socket_instance = socket.create_connection(host, timeout=DEFAULT_TIMEOUT)
+        except socket.error:
+            return None
+        socket_wrapper = context.wrap_socket(socket_instance, server_hostname=host[0])
+        return socket_wrapper

--- a/agent/exploits/cve_2024_21762.py
+++ b/agent/exploits/cve_2024_21762.py
@@ -124,7 +124,7 @@ Transfer-Encoding: chunked\r
     def _get_socket_wrapper(self, host: tuple[str, int]) -> ssl.SSLSocket | None:
         try:
             socket_instance = socket.create_connection(host, timeout=DEFAULT_TIMEOUT)
+            socket_wrapper = context.wrap_socket(socket_instance)
+            return socket_wrapper
         except socket.error:
             return None
-        socket_wrapper = context.wrap_socket(socket_instance)
-        return socket_wrapper

--- a/agent/exploits/cve_2024_21762.py
+++ b/agent/exploits/cve_2024_21762.py
@@ -124,7 +124,7 @@ Transfer-Encoding: chunked\r
     def _get_socket_wrapper(self, host: tuple[str, int]) -> ssl.SSLSocket | None:
         try:
             socket_instance = socket.create_connection(host, timeout=DEFAULT_TIMEOUT)
-            socket_wrapper = context.wrap_socket(socket_instance)
-            return socket_wrapper
         except socket.error:
             return None
+        socket_wrapper = context.wrap_socket(socket_instance, server_hostname=host[0])
+        return socket_wrapper

--- a/tests/exploits/cve_2023_48788_test.py
+++ b/tests/exploits/cve_2023_48788_test.py
@@ -14,8 +14,15 @@ def testCVE202348788_whenVulnerable_reportFinding(
     mocker: plugin.MockerFixture, requests_mock: req_mock.mocker.Mocker
 ) -> None:
     """CVE-2023-48788 unit test: case when target is vulnerable."""
+
+    def side_effect(*args):  # type: ignore[no-untyped-def]
+        if args[0] == 2047:
+            return b"KA_INTERVAL"
+        elif args[0] == 2048:
+            raise TimeoutError
+
     mock_socket = mock.MagicMock()
-    mock_socket.recv.return_value = b"KA_INTERVAL"
+    mock_socket.read.side_effect = side_effect
     mocker.patch("socket.socket", mock_socket)
     mocker.patch("ssl.SSLContext.wrap_socket", return_value=mock_socket)
     requests_mock.get(


### PR DESCRIPTION
Test case:
- Disabling the hostname check and the certificate verification leads to `Errno104`:
![Screenshot from 2024-04-24 12-11-17](https://github.com/Ostorlab/agent_asteroid/assets/110392140/7f7cdfb4-2e6d-4c17-9340-063e63d2a87e)
- Enabling the hostname check and the certificate verification makes the ssl wrapped connection work:
![Untitled design](https://github.com/Ostorlab/agent_asteroid/assets/110392140/fdf05ecf-ab5f-42a2-aa3a-bd2233dc1a22)

# Conclusion:
The first case that doesn't work may be due to the server's SSL/TLS configuration or the requirements of the server.