### PR TITLE
Remove jpype from requirement.txt

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -10,4 +10,3 @@ semantic_version
 impacket
 pysnmp==4.4.6
 jaydebeapi
-jpype1


### PR DESCRIPTION
jpype was used to handle `JException` by checking if `java.sql.SQLTransientConnectionException` is present in java exception when attempting to connect to the DB. Since this case is now handled by `jaydebeapi.DatabaseError`. It's no longer necessary to have it.