### PR TITLE
Add missing g++ required by jaydebeapi (JPype1).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11-slim as base
-RUN apt-get update && apt-get install -y default-jdk
+RUN apt-get update && apt-get install -y default-jdk g++
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV CLASSPATH=/app/agent/Resources/hsqldb.jar:$CLASSPATH
 FROM base as builder


### PR DESCRIPTION
Fixing buid failure due to  missing g++ reuired by   JPype1 which is required by jaydebeapi.

```python
#24 177.3 Building wheels for collected packages: adb-shell, impacket, JPype1, nats-py, py-ubjson, thrift
#24 177.3   Building wheel for adb-shell (setup.py): started
#24 180.5   Building wheel for adb-shell (setup.py): finished with status 'done'
#24 180.5   Created wheel for adb-shell: filename=adb_shell-0.4.4-py3-none-any.whl size=54530 sha256=1e6059a4daa77130a5fb812c80c150501585365909c9d7d80b5783f3a74e5436
#24 180.5   Stored in directory: /root/.cache/pip/wheels/4b/08/ed/4acfa21ef8c49e23c43991352f6efa3aa31d8d0834501a7b8b
#24 180.5   Building wheel for impacket (setup.py): started
#24 184.9   Building wheel for impacket (setup.py): finished with status 'done'
#24 184.9   Created wheel for impacket: filename=impacket-0.12.0-py3-none-any.whl size=1594818 sha256=f0713d34f8a25a42208e92ae7430b08eb246e7387db7c734b27cd5b8527e9bf0
#24 184.9   Stored in directory: /root/.cache/pip/wheels/26/8d/54/94a912acfc79c69fc4d3e4adfc073e0e1691849c5264002fa3
#24 185.0   Building wheel for JPype1 (pyproject.toml): started
#24 186.8   Building wheel for JPype1 (pyproject.toml): finished with status 'error'
#24 186.9   error: subprocess-exited-with-error
#24 186.9   
#24 186.9   × Building wheel for JPype1 (pyproject.toml) did not run successfully.
#24 186.9   │ exit code: 1
#24 186.9   ╰─> [62 lines of output]
#24 186.9       /tmp/pip-install-c7fvr6ma/jpype1_54c8ef6d8dad492197bff442ff6a79a2/setupext/pytester.py:20: SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
#24 186.9       !!
#24 186.9       
#24 186.9               ********************************************************************************
#24 186.9               Please remove any references to `setuptools.command.test` in all supported versions of the affected package.
#24 186.9       
#24 186.9               By 2024-Nov-15, you need to update your project and remove deprecated calls
#24 186.9               or your builds will no longer be supported.
#24 186.9               ********************************************************************************
#24 186.9       
#24 186.9       !!
#24 186.9         from setuptools.command.test import test as TestCommand
#24 186.9       /tmp/pip-build-env-_i__mow6/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py:261: UserWarning: Unknown distribution option: 'tests_require'
#24 186.9         warnings.warn(msg)
#24 186.9       running bdist_wheel
#24 186.9       running build
#24 186.9       running build_py
#24 186.9       creating build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jio.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/__init__.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jexception.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/protocol.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/imports.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_classpath.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jcustomizer.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_core.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jinit.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jproxy.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/pickle.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/nio.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jpackage.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_gui.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jmethod.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jclass.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jvmfinder.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_pykeywords.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/dbapi2.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jthread.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jobject.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jcollection.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jarray.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/config.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/beans.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/types.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jstring.py -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       creating build/lib.linux-aarch64-cpython-311/jpype/_pyinstaller
#24 186.9       copying jpype/_pyinstaller/entry_points.py -> build/lib.linux-aarch64-cpython-311/jpype/_pyinstaller
#24 186.9       copying jpype/_pyinstaller/example.py -> build/lib.linux-aarch64-cpython-311/jpype/_pyinstaller
#24 186.9       copying jpype/_pyinstaller/test_jpype_pyinstaller.py -> build/lib.linux-aarch64-cpython-311/jpype/_pyinstaller
#24 186.9       copying jpype/_pyinstaller/hook-jpype.py -> build/lib.linux-aarch64-cpython-311/jpype/_pyinstaller
#24 186.9       copying jpype/_jio.pyi -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       copying jpype/_jcollection.pyi -> build/lib.linux-aarch64-cpython-311/jpype
#24 186.9       running build_ext
#24 186.9       Call build extensions
#24 186.9       Using Jar cache
#24 186.9       copying native/jars/org.jpype.jar -> build/lib.linux-aarch64-cpython-311
#24 186.9       Call build ext
#24 186.9       building '_jpype' extension
#24 186.9       creating build/temp.linux-aarch64-cpython-311/native/common
#24 186.9       creating build/temp.linux-aarch64-cpython-311/native/python
#24 186.9       g++ -Wsign-compare -DNDEBUG -fwrapv -Wall -fPIC -Inative/common/include -Inative/python/include -Inative/embedded/include -Inative/jni_include -I/usr/local/include/python3.11 -c native/common/jp_array.cpp -o build/temp.linux-aarch64-cpython-311/native/common/jp_array.o -g0 -std=c++11 -O2
#24 186.9       error: command 'g++' failed: No such file or directory
#24 186.9       [end of output]
```