### PR TITLE
Adding detection for CVE-2024-45409

### DIFF
--- a/agent/exploits/cve_2024_45409.py
+++ b/agent/exploits/cve_2024_45409.py
@@ -1,6 +1,7 @@
 """Agent Asteroid implementation for CVE-2024-45409"""
 
 import re
+
 from agent import definitions
 from agent import exploits_registry
 from agent.exploits import webexploit

--- a/agent/exploits/cve_2024_45409.py
+++ b/agent/exploits/cve_2024_45409.py
@@ -1,0 +1,46 @@
+"""Agent Asteroid implementation for CVE-2024-45409"""
+
+import re
+from agent import definitions
+from agent import exploits_registry
+from agent.exploits import webexploit
+
+VULNERABILITY_TITLE = "GitLab SAML Authentication Bypass Vulnerability."
+VULNERABILITY_REFERENCE = "CVE-2024-45409"
+VULNERABILITY_DESCRIPTION = (
+    "An issue was discovered in GitLab CE/EE affecting all versions "
+    "prior to 17.0.8, 17.1.8, 17.2.7, 17.3.3, and 16.11.10. "
+    "An unauthenticated attacker with access to any signed saml document (by the IdP) can thus forge a SAML Response/Assertion "
+    "with arbitrary contents. This would allow the attacker to log in as arbitrary user within the vulnerable system."
+)
+RISK_RATING = "POTENTIALLY"
+
+VERSIONS_HASHES = [
+    "b52d3dd3b307bb936ad862671cae67163327a698f3dc2c4f232173d621af2a87",
+    "487de60d9ab3205ffe87ebd3b4dad8a80e7fa602d5390d64849d67476445b683",
+    "e2dd787585a2324e8c33f0c7f58327936bd32309cda3f49932b8fd439522e77b",
+    "22918e5e48d718e0977422d6c63347ce3199ac16206c958518b968c239529900",
+    "0c02a2d596fd75d35541f37fd7805ed373ffa2780d9e94cdd47650cc711514d0",
+    "6479d7d7b19cce99a8971e85a3756ea6f1debe89b68d0a86e69cc9c6e7414d7d",
+    "64ec030272495820a69a90e76affc1d0c47377c80f267ed21fa039c40404d4c9",
+    "bc8000290bc8c8c0ebadb5c9d96dac50df8244426ef375a23cfae334e9b100c2",
+    "1b91aa4fc5e5ae49577087b2b42821ac87b863ba4de61cdccdd6b3620f587608",
+    "f26176d736b2c98959127f2c53a94ba4c3c060368eb6797ad06dd923012b53bd",
+    "539db0d62ee9e10949bac79127c082aaa0e8d001ddda9467cd8a1d05928a9b8b",
+    "05a4322b27a3352f9638610b6a2528a03f90070a19fdb9e0499bb0412aad92fb",
+]
+
+
+@exploits_registry.register
+class CVE202445409Exploit(webexploit.WebExploit):
+    accept_request = definitions.Request(method="GET", path="/users/sign_in")
+    check_request = definitions.Request(method="GET", path="/users/sign_in")
+    accept_pattern = [re.compile("GitLab")]
+    match_pattern = [re.compile(version) for version in VERSIONS_HASHES]
+
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+    )

--- a/tests/exploits/cve_2024_45409_test.py
+++ b/tests/exploits/cve_2024_45409_test.py
@@ -29,7 +29,9 @@ def testCVE202445409_whenVulnerable_reportFinding(
     assert len(vulnerabilities) > 0
     vulnerability = vulnerabilities[0]
 
-    assert vulnerability.entry.title == "GitLab SAML Authentication Bypass Vulnerability."
+    assert (
+        vulnerability.entry.title == "GitLab SAML Authentication Bypass Vulnerability."
+    )
     assert (
         vulnerability.technical_detail
         == "https://localhost:8080 is vulnerable to CVE-2024-45409, GitLab SAML Authentication Bypass Vulnerability."

--- a/tests/exploits/cve_2024_45409_test.py
+++ b/tests/exploits/cve_2024_45409_test.py
@@ -1,0 +1,59 @@
+"""Unit tests for Agent Asteroid: CVE-2024-45409"""
+
+import requests_mock as req_mock
+
+
+from agent import definitions
+from agent.exploits import cve_2024_45409
+
+
+def testCVE202445409_whenVulnerable_reportFinding(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """Test exploit report finding when version is vulnerable."""
+    target = definitions.Target("https", "localhost", 8080)
+    requests_mock.get(
+        target.url + "users/sign_in",
+        status_code=200,
+        text="<title>Sign in · GitLab</title>"
+        '<link rel="preload" href="'
+        '/assets/application-b52d3dd3b307bb936ad862671cae67163327a698f3dc2c4f232173d621af2a87.css"'
+        ' as="style" type="text/css">',
+    )
+
+    exploit_instance = cve_2024_45409.CVE202445409Exploit()
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) > 0
+    vulnerability = vulnerabilities[0]
+
+    assert vulnerability.entry.title == "GitLab SAML Authentication Bypass Vulnerability."
+    assert (
+        vulnerability.technical_detail
+        == "https://localhost:8080 is vulnerable to CVE-2024-45409, GitLab SAML Authentication Bypass Vulnerability."
+    )
+    assert vulnerability.risk_rating.name == "POTENTIALLY"
+
+
+def testCVE202445409_whenNotVulnerable_reportNoFinding(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """Test exploit don't report finding."""
+    target = definitions.Target("https", "localhost", 8080)
+    requests_mock.get(
+        target.url + "users/sign_in",
+        status_code=200,
+        text="<title>Sign in · GitLab</title>"
+        '<link rel="preload" href="'
+        '/assets/application-b52d3dd3b307bb936ad862671cae67163327698f3dc2c4f232173d621af2a87.css"'
+        ' as="style" type="text/css">',
+    )
+
+    exploit_instance = cve_2024_45409.CVE202445409Exploit()
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 0


### PR DESCRIPTION
This detection is based on GitLab hashes to identify the version. We marked it as 'potentially' because some hashes also correspond to safe versions.

![image](https://github.com/user-attachments/assets/e4bb8015-0205-4fd2-8081-3678eac7e704)
Different versions can be found : 
https://github.com/ke0ge/gitlab-version-map/blob/f821f4b3d20bb5e53f253a1c05e9ded7c588bf56/automation/gitlab_hashes.json