### PR TITLE
Add detection for CVE-2024-37383

### DIFF
--- a/agent/exploits/cve_2024_37383.py
+++ b/agent/exploits/cve_2024_37383.py
@@ -1,0 +1,36 @@
+"""Agent Asteroid implementation for CVE-2024-37383"""
+
+import re
+
+from agent import definitions
+from agent import exploits_registry
+from agent.exploits import webexploit
+
+VULNERABILITY_TITLE = "XSS via SVG Animate Attributes in Roundcube Webmail"
+VULNERABILITY_REFERENCE = "CVE-2024-37383"
+VULNERABILITY_DESCRIPTION = (
+    "Roundcube Webmail before version 1.5.7 and versions 1.6.x before 1.6.7 contains a "
+    "cross-site scripting vulnerability that can be exploited via SVG animate attributes."
+)
+RISK_RATING = "HIGH"
+
+
+@exploits_registry.register
+class CVE202437383Exploit(webexploit.WebExploit):
+    accept_request = definitions.Request(method="GET", path="/")
+    check_request = definitions.Request(method="GET", path="/")
+    accept_pattern = [re.compile('"rcversion":')]
+
+    # Matches:
+    # - All versions up to 1.5.7 (10507)
+    # - Versions 1.6.0 through 1.6.6 (10600-10606)
+    match_pattern = [
+        re.compile(r'"rcversion":\s*(?:[0-1]0[0-5]0[0-6]|1060[0-6])'),
+    ]
+
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+    )

--- a/agent/exploits/cve_2024_37383.py
+++ b/agent/exploits/cve_2024_37383.py
@@ -12,7 +12,7 @@ VULNERABILITY_DESCRIPTION = (
     "Roundcube Webmail before version 1.5.7 and versions 1.6.x before 1.6.7 contains a "
     "cross-site scripting vulnerability that can be exploited via SVG animate attributes."
 )
-RISK_RATING = "HIGH"
+RISK_RATING = "MEDIUM"
 
 
 @exploits_registry.register

--- a/tests/exploits/cve_2024_37383_test.py
+++ b/tests/exploits/cve_2024_37383_test.py
@@ -1,0 +1,81 @@
+"""Unit tests for Agent Asteroid: CVE-2024-37383"""
+
+import requests_mock as req_mock
+
+from agent import definitions
+from agent.exploits import cve_2024_37383
+
+
+def testCVE202437383_whenVersion156_reportFinding(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-37383 unit test: case when target is vulnerable (1.5.6)."""
+    requests_mock.get(
+        "http://localhost:80/",
+        text="""{"rcversion":10506,"product":"Roundcube Webmail"}""",
+        status_code=200,
+    )
+    exploit_instance = cve_2024_37383.CVE202437383Exploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) > 0
+    vulnerability = vulnerabilities[0]
+    assert (
+        vulnerability.entry.title
+        == "XSS via SVG Animate Attributes in Roundcube Webmail"
+    )
+    assert vulnerability.technical_detail == (
+        "http://localhost:80 is vulnerable to CVE-2024-37383, "
+        "XSS via SVG Animate Attributes in Roundcube Webmail"
+    )
+
+
+def testCVE202437383_whenVersion166_reportFinding(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-37383 unit test: case when target is vulnerable (1.6.6)."""
+    requests_mock.get(
+        "http://localhost:80/",
+        text="""{"rcversion":10606,"product":"Roundcube Webmail"}""",
+        status_code=200,
+    )
+    exploit_instance = cve_2024_37383.CVE202437383Exploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) > 0
+    vulnerability = vulnerabilities[0]
+    assert (
+        vulnerability.entry.title
+        == "XSS via SVG Animate Attributes in Roundcube Webmail"
+    )
+    assert vulnerability.technical_detail == (
+        "http://localhost:80 is vulnerable to CVE-2024-37383, "
+        "XSS via SVG Animate Attributes in Roundcube Webmail"
+    )
+
+
+def testCVE202437383_whenSafe_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-37383 unit test: case when target is safe."""
+    requests_mock.get(
+        "http://localhost:80/",
+        text="""{"rcversion":10607,"product":"Roundcube Webmail"}""",
+        status_code=200,
+    )
+    exploit_instance = cve_2024_37383.CVE202437383Exploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 0


### PR DESCRIPTION
## Description

Adds vulnerability detection for `CVE-2024-37383`, a cross-site scripting vulnerability in Roundcube Webmail that affects versions before `1.5.7` and `1.6.x` before `1.6.7`.

### Implementation Details

- Detects vulnerable Roundcube versions by matching the `rcversion` field in the application's root path response
- Uses simple regex pattern to match vulnerable version ranges:
  - All versions up to `1.5.6` (`[0-1]0[0-5]0[0-6]`)
  - Versions `1.6.0` through `1.6.6` (`1060[0-6]`)

![image](https://github.com/user-attachments/assets/db4ae623-7d81-4d3a-900b-ec81cdf160fe)

