### PR TITLE
Add version based detection for litespeed cache plugin CVE-2024-50550

### DIFF
--- a/agent/exploits/cve_2024_50550.py
+++ b/agent/exploits/cve_2024_50550.py
@@ -1,0 +1,39 @@
+"""Agent Asteroid implementation for CVE-2024-50550"""
+
+import re
+
+from packaging import version
+
+from agent import definitions
+from agent import exploits_registry
+from agent.exploits import webexploit
+
+VERSION_PATTERN = re.compile(r"Stable tag:\s(\d+\.\d+\.\d+)")
+MAX_VULNERABLE_VERSION = version.parse("6.5.1")
+VULNERABILITY_TITLE = "LiteSpeed Cache Vulnerability Allowing privilege escalation"
+VULNERABILITY_REFERENCE = "CVE-2024-50550"
+VULNERABILITY_DESCRIPTION = (
+    "Incorrect Privilege Assignment vulnerability in LiteSpeed Technologies LiteSpeed Cache allows Privilege Escalation."
+    "This issue affects LiteSpeed Cache versions before 6.5.2."
+)
+RISK_RATING = "HIGH"
+
+
+@exploits_registry.register
+class CVE202450550Exploit(webexploit.WebExploit):
+    accept_request = definitions.Request(
+        method="GET", path="/wp-content/plugins/litespeed-cache/readme.txt"
+    )
+    check_request = definitions.Request(
+        method="GET", path="/wp-content/plugins/litespeed-cache/readme.txt"
+    )
+    accept_pattern = [re.compile("LiteSpeed Cache")]
+    version_pattern = VERSION_PATTERN
+    vuln_ranges = [definitions.VulnRange(None, MAX_VULNERABLE_VERSION)]
+
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+    )

--- a/tests/exploits/cve_2024_50550_test.py
+++ b/tests/exploits/cve_2024_50550_test.py
@@ -1,0 +1,82 @@
+"""Unit tests for Agent Asteroid: CVE-2024-50550"""
+
+import requests_mock as req_mock
+
+from agent import definitions
+from agent.exploits import cve_2024_50550
+
+
+def testCVE202450550_whenVulnerable_reportFinding(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-50550 unit test: case when target is vulnerable."""
+    requests_mock.get(
+        "http://localhost:80/wp-content/plugins/litespeed-cache/readme.txt",
+        text="""=== LiteSpeed Cache ===
+                    Contributors: LiteSpeedTech
+                    Tags: caching, optimize, performance, pagespeed, seo, image optimize, object cache, redis, memcached, database cleaner
+                    Requires at least: 4.9
+                    Tested up to: 6.6.1
+                    Stable tag: 6.5.1""",
+        status_code=200,
+    )
+    exploit_instance = cve_2024_50550.CVE202450550Exploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) > 0
+    vulnerability = vulnerabilities[0]
+    assert (
+        vulnerability.entry.title
+        == "LiteSpeed Cache Vulnerability Allowing privilege escalation"
+    )
+    assert vulnerability.technical_detail == (
+        "http://localhost:80 is vulnerable to CVE-2024-50550, LiteSpeed "
+        "Cache Vulnerability Allowing privilege escalation"
+    )
+
+
+def testCVE202450550_whenSafe_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-50550 unit test: case when target is safe."""
+    exploit_instance = cve_2024_50550.CVE202450550Exploit()
+    requests_mock.get(
+        "http://localhost:80/wp-content/plugins/litespeed-cache/readme.txt",
+        text="""=== LiteSpeed Cache ===
+                Contributors: LiteSpeedTech
+                Tags: caching, optimize, performance, pagespeed, seo, image optimize, object cache, redis, memcached, database cleaner
+                Requires at least: 4.9
+                Tested up to: 6.6.1
+                Stable tag: 6.5.2""",
+        status_code=200,
+    )
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 0
+
+
+def testCVE202450550_whenTargetNotLiteSpeedCache_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-50550 unit test: case when target is safe."""
+    exploit_instance = cve_2024_50550.CVE202450550Exploit()
+    requests_mock.get(
+        "http://localhost:80/wp-content/plugins/litespeed-cache/readme.txt",
+        text="""Not Found""",
+        status_code=404,
+    )
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is False
+    assert len(vulnerabilities) == 0


### PR DESCRIPTION
This PR is for adding a version based detection for CVE-2024-50550 which is a litespeed privilege escalation vulnerability.
this detection is based on the webexploit base class so it's only working by passing a range of the vulnerable versions which is all the versions before 6.5.2.
![image](https://github.com/user-attachments/assets/08756f5e-5699-4880-bdf7-2f35963d9af9)

 