### PR TITLE
Adding CVE-2024_42509

### DIFF
--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -1,0 +1,151 @@
+"""Agent Asteroid implementation for CVE-2024-42509"""
+
+import logging
+import re
+
+from pysnmp import hlapi
+from packaging import version as ver
+from ostorlab.agent.kb import kb
+from ostorlab.agent.mixins import agent_report_vulnerability_mixin
+from agent import definitions
+from agent import exploits_registry
+
+VULNERABILITY_TITLE = "Unauthenticated Command Injection Vulnerability in HPE Aruba Networking Access Points"
+VULNERABILITY_REFERENCE = "CVE-2024-42509"
+VULNERABILITY_DESCRIPTION = (
+    "Command injection vulnerability in the underlying CLI service could lead to unauthenticated "
+    "remote code execution by sending specially crafted packets destined to the PAPI (Aruba's Access Point management protocol) "
+    "UDP port (8211). Successful exploitation of this vulnerability results in the ability to execute arbitrary code as a privileged user "
+    "on the underlying operating system."
+)
+DEFAULT_TIMEOUT = 30
+
+VULNERABLE_VERSION_FAMILIES = [
+    "10.4",
+    "8.12",
+    "8.10",
+    "10.6",
+    "10.5",
+    "10.3",
+    "8.11",
+    "8.9",
+    "8.8",
+    "8.7",
+    "8.6",
+    "8.5",
+    "8.4",
+    "6.5",
+    "6.4",
+]
+VULNERABLE_VERSIONS = {
+    "10.4": "10.4.1.4",  # Vulnerable version for family 10.4 and below
+    "8.12": "8.12.0.2",  # Vulnerable version for family 8.12 and below
+    "8.10": "8.10.0.13",  # Vulnerable version for family 8.10 and below
+}
+
+
+SNMP_DESCRIPTION_PATTERN = (
+    r"ArubaOS \(MODEL: \S+\), Version (\d+\.\d+\.\d+\.\d+|\d+\.\d+\.\d+)"
+)
+
+
+def _is_version_vulnerable(version: str) -> bool:
+    """Checks whether a given software version is vulnerable based on predefined version families and thresholds."""
+    # Split version into family and specific version
+    family = ".".join(
+        version.split(".")[:2]
+    )  # Take first two parts as family, e.g., 8.9 or 10.4
+
+    # Check if version family is in vulnerable families
+    if family in VULNERABLE_VERSION_FAMILIES:
+        if family in VULNERABLE_VERSIONS:
+            # If specific version is less than or equal to the threshold, it's vulnerable
+            threshold_version = VULNERABLE_VERSIONS[family]
+            return ver.parse(version) <= ver.parse(threshold_version)
+        else:
+            # If no specific version threshold exists, assume it's vulnerable for this family
+            return True
+
+    return False
+
+
+def _get_aruba_version(host: str) -> str | None:
+    """Send SNMP request to retrieve the system description."""
+    version = None
+    iterator = hlapi.getCmd(
+        hlapi.SnmpEngine(),
+        hlapi.CommunityData("public", mpModel=1),
+        hlapi.UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT),
+        hlapi.ContextData(),
+        hlapi.ObjectType(hlapi.ObjectIdentity("1.3.6.1.2.1.1.1.0")),  # sysDescr OID
+    )
+    error_indication, error_status, error_index, var_binds = next(iterator)
+
+    if error_indication:
+        logging.error("SNMP error_indication: %s", error_indication)
+    elif error_status:
+        logging.error("SNMP error_status: %s at %s", error_status, error_index)
+    else:
+        for var_bind in var_binds:
+            description = var_bind[1].prettyPrint()
+            logging.info("ArubaOS description found: %s", description)
+            match = re.search(SNMP_DESCRIPTION_PATTERN, description)
+            if match:
+                version = match.group(1)
+                logging.info("ArubaOS version extracted: %s", version)
+
+    return version
+
+
+def _create_vulnerability(
+    target: definitions.Target, version: str
+) -> definitions.Vulnerability:
+    entry = kb.Entry(
+        title=VULNERABILITY_TITLE,
+        risk_rating="CRITICAL",
+        short_description=VULNERABILITY_DESCRIPTION,
+        description=f"{VULNERABILITY_DESCRIPTION} Detected version: {version}",
+        references={
+            "nvd.nist.gov": f"https://nvd.nist.gov/vuln/detail/{VULNERABILITY_REFERENCE}",
+        },
+        recommendation=(
+            "- Update HPE Aruba Networking Access Points to the latest version "
+        ),
+        security_issue=True,
+        privacy_issue=False,
+        has_public_exploit=False,
+        targeted_by_malware=False,
+        targeted_by_ransomware=False,
+        targeted_by_nation_state=False,
+    )
+    technical_detail = (
+        f"HPE Aruba Networking Access Points device at {target.origin} is running a vulnerable version: {version}. "
+        f"Immediate action is required."
+    )
+    vulnerability = definitions.Vulnerability(
+        entry=entry,
+        technical_detail=technical_detail,
+        risk_rating=agent_report_vulnerability_mixin.RiskRating.CRITICAL,
+    )
+    return vulnerability
+
+
+@exploits_registry.register
+class CVE202442509Exploit(definitions.Exploit):
+    """
+    CVE-2024-42509: Unauthenticated Command Injection Vulnerability
+    """
+
+    def accept(self, target: definitions.Target) -> bool:
+        version = _get_aruba_version(target.host)
+        return bool(version)
+
+    def check(self, target: definitions.Target) -> list[definitions.Vulnerability]:
+        vulnerabilities: list[definitions.Vulnerability] = []
+        version = _get_aruba_version(target.host)
+
+        if version and _is_version_vulnerable(version):
+            vulnerability = _create_vulnerability(target, version)
+            vulnerabilities.append(vulnerability)
+
+        return vulnerabilities

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import datetime
 
 from pysnmp import hlapi
 from packaging import version as ver
@@ -19,7 +20,7 @@ VULNERABILITY_DESCRIPTION = (
     "UDP port (8211). Successful exploitation of this vulnerability results in the ability to execute arbitrary code as a privileged user "
     "on the underlying operating system."
 )
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = datetime.timedelta(seconds=90)
 
 VULNERABLE_VERSION_FAMILIES = [
     "10.4",
@@ -76,7 +77,7 @@ def _get_aruba_version(host: str) -> str | None:
     iterator = hlapi.getCmd(
         hlapi.SnmpEngine(),
         hlapi.CommunityData("public", mpModel=1),
-        hlapi.UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT),
+        hlapi.UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
         hlapi.ContextData(),
         hlapi.ObjectType(hlapi.ObjectIdentity(OID)),  # sysDescr OID
     )

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -82,9 +82,9 @@ def _get_aruba_version(host: str) -> str | None:
     )
     error_indication, error_status, error_index, var_binds = next(iterator)
 
-    if error_indication is not None:
+    if error_indication is True:
         logging.error("SNMP error_indication: %s", error_indication)
-    elif error_status is not None:
+    elif error_status is True:
         logging.error("SNMP error_status: %s at %s", error_status, error_index)
     else:
         for var_bind in var_binds:

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -7,6 +7,7 @@ from pysnmp import hlapi
 from packaging import version as ver
 from ostorlab.agent.kb import kb
 from ostorlab.agent.mixins import agent_report_vulnerability_mixin
+
 from agent import definitions
 from agent import exploits_registry
 
@@ -43,7 +44,7 @@ VULNERABLE_VERSIONS = {
     "8.10": "8.10.0.13",  # Vulnerable version for family 8.10 and below
 }
 
-
+OID = "1.3.6.1.2.1.1.1.0"
 SNMP_DESCRIPTION_PATTERN = (
     r"ArubaOS \(MODEL: \S+\), Version (\d+\.\d+\.\d+\.\d+|\d+\.\d+\.\d+)"
 )
@@ -77,20 +78,20 @@ def _get_aruba_version(host: str) -> str | None:
         hlapi.CommunityData("public", mpModel=1),
         hlapi.UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT),
         hlapi.ContextData(),
-        hlapi.ObjectType(hlapi.ObjectIdentity("1.3.6.1.2.1.1.1.0")),  # sysDescr OID
+        hlapi.ObjectType(hlapi.ObjectIdentity(OID)),  # sysDescr OID
     )
     error_indication, error_status, error_index, var_binds = next(iterator)
 
-    if error_indication:
+    if error_indication is not None:
         logging.error("SNMP error_indication: %s", error_indication)
-    elif error_status:
+    elif error_status is not None:
         logging.error("SNMP error_status: %s at %s", error_status, error_index)
     else:
         for var_bind in var_binds:
             description = var_bind[1].prettyPrint()
             logging.info("ArubaOS description found: %s", description)
             match = re.search(SNMP_DESCRIPTION_PATTERN, description)
-            if match:
+            if match is not None:
                 version = match.group(1)
                 logging.info("ArubaOS version extracted: %s", version)
 
@@ -144,7 +145,7 @@ class CVE202442509Exploit(definitions.Exploit):
         vulnerabilities: list[definitions.Vulnerability] = []
         version = _get_aruba_version(target.host)
 
-        if version and _is_version_vulnerable(version):
+        if version is not None and _is_version_vulnerable(version) is True:
             vulnerability = _create_vulnerability(target, version)
             vulnerabilities.append(vulnerability)
 

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -2,7 +2,6 @@
 
 import logging
 import re
-import datetime
 
 from pysnmp import hlapi
 from packaging import version as ver
@@ -20,7 +19,7 @@ VULNERABILITY_DESCRIPTION = (
     "UDP port (8211). Successful exploitation of this vulnerability results in the ability to execute arbitrary code as a privileged user "
     "on the underlying operating system."
 )
-DEFAULT_TIMEOUT = datetime.timedelta(seconds=90)
+DEFAULT_TIMEOUT = 30
 
 VULNERABLE_VERSION_FAMILIES = [
     "10.4",

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import datetime
 
 from pysnmp import hlapi
 from packaging import version as ver
@@ -19,7 +20,7 @@ VULNERABILITY_DESCRIPTION = (
     "UDP port (8211). Successful exploitation of this vulnerability results in the ability to execute arbitrary code as a privileged user "
     "on the underlying operating system."
 )
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = datetime.timedelta(seconds=90)
 
 VULNERABLE_VERSION_FAMILIES = [
     "10.4",

--- a/tests/exploits/cve_2024_42509_test.py
+++ b/tests/exploits/cve_2024_42509_test.py
@@ -1,7 +1,9 @@
 """Unit tests for Agent Asteroid: CVE-2024-42509"""
 
 from unittest import mock
+
 from pytest_mock import plugin
+
 from agent import definitions
 from agent.exploits import cve_2024_42509
 

--- a/tests/exploits/cve_2024_42509_test.py
+++ b/tests/exploits/cve_2024_42509_test.py
@@ -1,0 +1,106 @@
+from unittest import mock
+from pytest_mock import plugin
+from agent import definitions
+from agent.exploits import cve_2024_42509
+
+
+def testCVE202442509_whenVulnerable_reportFinding(mocker: plugin.MockerFixture) -> None:
+    """CVE-2024-42509 unit test: case when target is vulnerable."""
+
+    vulnerable_version = "8.10.0.13"
+    mock_var_bind = mock.MagicMock()
+    mock_var_bind.__getitem__.return_value.prettyPrint.return_value = (
+        f"ArubaOS (MODEL: AP-325), Version {vulnerable_version}"
+    )
+
+    mock_iterator = mock.MagicMock()
+    mock_iterator.__next__.return_value = (False, False, False, [mock_var_bind])
+    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+
+    exploit_instance = cve_2024_42509.CVE202442509Exploit()
+
+    target = definitions.Target("udp", "192.168.1.2", 161)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 1
+    vulnerability = vulnerabilities[0]
+    assert vulnerability.entry.title == cve_2024_42509.VULNERABILITY_TITLE
+    assert vulnerability.entry.risk_rating == "CRITICAL"
+    assert vulnerability.technical_detail == (
+        f"HPE Aruba Networking Access Points device at udp://192.168.1.2:161 is running a vulnerable version: {vulnerable_version}. "
+        "Immediate action is required."
+    )
+
+
+def testCVE202442509_whenSafe_reportNothing(mocker: plugin.MockerFixture) -> None:
+    """CVE-2024-42509 unit test: case when target is not vulnerable."""
+
+    safe_version = "10.4.1.5"
+    mock_var_bind = mock.MagicMock()
+    mock_var_bind.__getitem__.return_value.prettyPrint.return_value = (
+        f"ArubaOS (MODEL: AP-325), Version {safe_version}"
+    )
+
+    mock_iterator = mock.MagicMock()
+    mock_iterator.__next__.return_value = (False, False, False, [mock_var_bind])
+    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+
+    exploit_instance = cve_2024_42509.CVE202442509Exploit()
+
+    target = definitions.Target("udp", "192.168.1.2", 161)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 0
+
+
+def testCVE202442509_whenVersionNotFound_reportNothing(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """CVE-2024-42509 unit test: case when version cannot be determined."""
+
+    mock_var_bind = mock.MagicMock()
+    mock_var_bind.__getitem__.return_value.prettyPrint.return_value = (
+        "Unexpected response"
+    )
+
+    mock_iterator = mock.MagicMock()
+    mock_iterator.__next__.return_value = (False, False, False, [mock_var_bind])
+    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+
+    exploit_instance = cve_2024_42509.CVE202442509Exploit()
+
+    target = definitions.Target("udp", "192.168.1.2", 161)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is False
+    assert len(vulnerabilities) == 0
+
+
+def testCVE202442509_whenSNMPError_handleGracefully(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """CVE-2024-42509 unit test: case when SNMP returns an error."""
+
+    mock_iterator = mock.MagicMock()
+    mock_iterator.__next__.return_value = (True, False, False, [])
+    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mock_logging = mocker.patch("logging.error")
+
+    exploit_instance = cve_2024_42509.CVE202442509Exploit()
+
+    target = definitions.Target("udp", "192.168.1.2", 161)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is False
+    assert len(vulnerabilities) == 0
+    mock_logging.assert_called_with("SNMP error_indication: %s", True)

--- a/tests/exploits/cve_2024_42509_test.py
+++ b/tests/exploits/cve_2024_42509_test.py
@@ -1,3 +1,5 @@
+"""Unit tests for Agent Asteroid: CVE-2024-42509"""
+
 from unittest import mock
 from pytest_mock import plugin
 from agent import definitions


### PR DESCRIPTION
Vulnerability Summary: This PR implements an exploit check for CVE-2024-42509, an unauthenticated command injection vulnerability in HPE Aruba Networking Access Points. The vulnerability allows remote code execution due to a command injection flaw in the underlying CLI service. Specifically, the vulnerability is triggered by sending specially crafted packets to UDP port 8211, used by Aruba's Access Point management protocol (PAPI). However, due to the lack of a publicly available  (PoC) for the exploit, direct testing on UDP port 8211 is not feasible in this implementation.

Approach: To determine if a target device is running a vulnerable version of ArubaOS (AOS), we leveraged the SNMP (Simple Network Management Protocol) service. SNMP provides a reliable way to retrieve the AOS version by querying the system description, which can be accessed via the standard sysDescr OID. This OID reveals details about the device's OS, including the version of ArubaOS running on the access point.

Rationale: By querying SNMP to determine the AOS version, we can indirectly assess whether the device is susceptible to CVE-2024-42509. Once we retrieve the version, we compare it against a predefined list of vulnerable AOS versions. If the version falls within this list, the device is flagged as potentially vulnerable.