### PR TITLE
Fix for psycopg Dependency Issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.11-slim as base
-RUN apt-get update && apt-get install -y default-jdk g++
+RUN apt-get update && apt-get install -y \
+    default-jdk \
+    g++ \
+    libpq-dev \
+    --no-install-recommends \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV CLASSPATH=/app/agent/Resources/hsqldb.jar:$CLASSPATH
 FROM base as builder


### PR DESCRIPTION
## **Fix psycopg Dependency Issue in Agent Asteroid**

### **Description:** 

This PR resolves a dependency issue in the Agent Asteroid Docker image, where the `psycopg` library failed to initialize due to missing system dependencies. The issue caused the agent to crash during initialization when attempting to load PostgreSQL-related functionality.

### **Key Changes:**

- Updated the Dockerfile to include the `libpq-dev` package, ensuring `psycopg` can properly load its required libraries.
- Enhanced the `apt-get` commands to include cache cleaning for smaller image sizes.
- Verified `psycopg` functionality during the build process.

![image](https://github.com/user-attachments/assets/ef5c5fd4-8bff-4ded-93e9-a62fbbf5451f)
