### PR TITLE
Slow Unittesting in Agent Asteroid

### DIFF
--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -1,6 +1,6 @@
 """Unit tests for AsteroidAgent."""
 
-from typing import Callable, Iterator, Type
+from typing import Any, Iterator, Type
 
 import requests
 import requests_mock
@@ -33,7 +33,7 @@ def testAsteroidAgent_whenTooManyRedirects_doesNotCrash(
 ) -> None:
     """Ensure that the agent does not crash when there are too many redirects."""
 
-    def response_callback(request: requests.Request, context: Callable) -> str:
+    def response_callback(request: Any, context: Any) -> str:
         context.headers = {"Location": request.url}
         context.status_code = 302
         return ""

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -59,3 +59,4 @@ def testAsteroidAgent_whenTooManyRedirects_doesNotCrash(
     asteroid_agent_instance.process(msg)
 
     assert len(agent_mock) == 1
+    assert agent_mock[0].selector == "v3.report.vulnerability"

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -16,6 +16,7 @@ def testAsteroidAgent_whenExploitCheckDetectVulnz_EmitsVulnerabilityReport(
     agent_mock: list[m.Message],
     scan_message_domain_name: m.Message,
     mocker: plugin.MockerFixture,
+    requests_mock: requests_mock.Mocker,
 ) -> None:
     """Unit test for agent AsteroidAgent exploits check. case Exploit emits vulnerability report"""
 

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -3,6 +3,7 @@
 from typing import Callable, Iterator, Type
 
 import requests
+import agent
 import requests_mock
 from ostorlab.agent.message import message as m
 from pytest_mock import plugin
@@ -58,3 +59,5 @@ def testAsteroidAgent_whenTooManyRedirects_doesNotCrash(
         raw=b"\n\x19https://example.com\x12\x03GET",
     )
     asteroid_agent_instance.process(msg)
+
+    assert len(agent_mock) == 1

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -3,7 +3,6 @@
 from typing import Callable, Iterator, Type
 
 import requests
-import agent
 import requests_mock
 from ostorlab.agent.message import message as m
 from pytest_mock import plugin

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -15,12 +15,23 @@ def testAsteroidAgent_whenExploitCheckDetectVulnz_EmitsVulnerabilityReport(
     asteroid_agent_instance: asteroid_agent.AsteroidAgent,
     agent_mock: list[m.Message],
     scan_message_domain_name: m.Message,
+    mocker: plugin.MockerFixture,
 ) -> None:
     """Unit test for agent AsteroidAgent exploits check. case Exploit emits vulnerability report"""
 
+    mock_var_bind = mocker.MagicMock()
+    mock_var_bind.__getitem__.return_value.prettyPrint.return_value = (
+        "ArubaOS (MODEL: 7005), Version 8.5.0.0"
+    )
+    mock_iterator = mocker.MagicMock()
+    mock_iterator.__next__.return_value = (None, None, None, [mock_var_bind])
+    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+
+    requests_mock.register_uri(ANY, ANY, status_code=404, text="")
+
     asteroid_agent_instance.process(scan_message_domain_name)
 
-    assert len(agent_mock) == 1
+    assert len(agent_mock) > 0
     assert agent_mock[0].selector == "v3.report.vulnerability"
 
 

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -1,11 +1,14 @@
 """Unit tests for AsteroidAgent."""
 
-from typing import Type, Iterator
+from typing import Callable, Iterator, Type
 
+import requests
+import requests_mock
 from ostorlab.agent.message import message as m
+from pytest_mock import plugin
+from requests_mock.adapter import ANY
 
-from agent import asteroid_agent
-from agent import definitions
+from agent import asteroid_agent, definitions
 
 
 def testAsteroidAgent_whenExploitCheckDetectVulnz_EmitsVulnerabilityReport(
@@ -23,18 +26,35 @@ def testAsteroidAgent_whenExploitCheckDetectVulnz_EmitsVulnerabilityReport(
 
 
 def testAsteroidAgent_whenTooManyRedirects_doesNotCrash(
-    exploit_instance_with_report: Iterator[Type[definitions.Exploit]],
     asteroid_agent_instance: asteroid_agent.AsteroidAgent,
     agent_mock: list[m.Message],
+    mocker: plugin.MockerFixture,
+    requests_mock: requests_mock.Mocker,
 ) -> None:
     """Ensure that the agent does not crash when there are too many redirects."""
-    msg = m.Message(
-        selector="v3.asset.link",
-        data={"url": "https://expediaagents.com", "method": "GET"},
-        raw=b"\n\x19https://expediaagents.com\x12\x03GET",
+
+    def response_callback(request: requests.Request, context: Callable) -> str:
+        context.headers = {"Location": request.url}
+        context.status_code = 302
+        return ""
+
+    requests_mock.register_uri(
+        ANY,
+        ANY,
+        text=response_callback,
     )
 
-    asteroid_agent_instance.process(msg)
+    mock_var_bind = mocker.MagicMock()
+    mock_var_bind.__getitem__.return_value.prettyPrint.return_value = (
+        "ArubaOS (MODEL: 7005), Version 8.5.0.0"
+    )
+    mock_iterator = mocker.MagicMock()
+    mock_iterator.__next__.return_value = (None, None, None, [mock_var_bind])
+    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
 
-    assert len(agent_mock) == 1
-    assert agent_mock[0].selector == "v3.report.vulnerability"
+    msg = m.Message(
+        selector="v3.asset.link",
+        data={"url": "https://example.com", "method": "GET"},
+        raw=b"\n\x19https://example.com\x12\x03GET",
+    )
+    asteroid_agent_instance.process(msg)

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Iterator, Type
 
-import requests
 import requests_mock
 from ostorlab.agent.message import message as m
 from pytest_mock import plugin


### PR DESCRIPTION
## Slow unittesting
One unittest was taking too much time because it was using an actual website to tests the exploits. This is not optimal because the responses might change over time, so they want always fit the scenario we are aiming to replicate (Too many redirects in this case). These requests also took a lot of time to be resolved.

## Fix
Mock both `requests.request` and `pysnmp.hlapi.getCmd`, while still simulating the `TooManyRedirects` behavior.
This was done by mocking requests to return `status_code=302`, and a `location: same_url` header.

## Where the test duration went up

Timeout was increased from 30 to 90
Which definitely contributed to the unittest duration increase

![image](https://github.com/user-attachments/assets/2cb3a68f-d25e-4360-9f77-a324fc2a40b1)

