### PR TITLE
Add version based detection for CVE-2024-54134

### DIFF
--- a/agent/exploits/cve_2024_54134.py
+++ b/agent/exploits/cve_2024_54134.py
@@ -3,9 +3,10 @@
 import re
 
 from packaging import version
-from agent.exploits import webexploit
-from agent import exploits_registry
+
 from agent import definitions
+from agent import exploits_registry
+from agent.exploits import webexploit
 
 VULNERABILITY_TITLE = "MALICIOUS PACKAGES FOUND IN COMPROMISED @SOLANA/WEB3.JS LIBRARY"
 VULNERABILITY_REFERENCE = "CVE-2024-54134"

--- a/agent/exploits/cve_2024_54134.py
+++ b/agent/exploits/cve_2024_54134.py
@@ -1,0 +1,34 @@
+"""Agent Asteroid implementation for CVE-2024-54134"""
+
+import re
+
+from packaging import version
+from agent.exploits import webexploit
+from agent import exploits_registry
+from agent import definitions
+
+VULNERABILITY_TITLE = "MALICIOUS PACKAGES FOUND IN COMPROMISED @SOLANA/WEB3.JS LIBRARY"
+VULNERABILITY_REFERENCE = "CVE-2024-54134"
+VULNERABILITY_DESCRIPTION = """A compromised publish-access account for the @solana/web3.js library allowed attackers to release malicious packages (versions 1.95.6 and 1.95.7).
+These packages were modified to steal private key material, potentially draining funds from affected Solana dapps that handle private keys directly"""
+RISK_RATING = "HIGH"
+MIN_VULNERABLE_VERSION = version.parse("1.95.6")
+MAX_VULNERABLE_VERSION = version.parse("1.95.7")
+VERSION_PATTERN = re.compile(r"@solana/web3\.js@(\d+\.\d+\.\d+)")
+
+
+@exploits_registry.register
+class CVE202454134Exploit(webexploit.WebExploit):
+    accept_request = definitions.Request(method="GET", path="/")
+    check_request = definitions.Request(method="GET", path="/")
+    accept_pattern = [re.compile("https://unpkg\.com/@solana/web3\.js")]
+    vuln_ranges = [
+        definitions.VulnRange(MIN_VULNERABLE_VERSION, MAX_VULNERABLE_VERSION)
+    ]
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+    )
+    version_pattern = VERSION_PATTERN

--- a/tests/exploits/cve_2024_54134_test.py
+++ b/tests/exploits/cve_2024_54134_test.py
@@ -1,0 +1,52 @@
+"""Unit tests for Agent Asteroid: CVE-2024-54134"""
+
+import requests_mock as req_mock
+
+from agent import definitions
+from agent.exploits import cve_2024_54134
+
+
+def testCVE202454134_whenVulnerable_reportFinding(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-54134 unit test: case when target is vulnerable."""
+    requests_mock.get(
+        "http://localhost:80/",
+        text='<script src="https://unpkg.com/@solana/web3.js@1.95.7/lib/index.iife.min.js"></script>',
+        status_code=200,
+    )
+    exploit_instance = cve_2024_54134.CVE202454134Exploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) > 0
+    vulnerability = vulnerabilities[0]
+    assert (
+        vulnerability.entry.title
+        == "MALICIOUS PACKAGES FOUND IN COMPROMISED @SOLANA/WEB3.JS LIBRARY"
+    )
+    assert vulnerability.technical_detail == (
+        "http://localhost:80 is vulnerable to CVE-2024-54134, MALICIOUS PACKAGES FOUND IN COMPROMISED @SOLANA/WEB3.JS LIBRARY"
+    )
+
+
+def testCVE202454134_whenSafe_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-54134 unit test: case when target is safe."""
+    exploit_instance = cve_2024_54134.CVE202454134Exploit()
+    requests_mock.get(
+        "http://localhost:80/",
+        text='<script src="https://unpkg.com/@solana/web3.js@1.95.8/lib/index.iife.min.js"></script>',
+        status_code=200,
+    )
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 0


### PR DESCRIPTION
This PR adds version-based detection for **CVE-2024-54134**, a vulnerability in the `@solana/web3.js` library, specifically in versions **1.95.6** and **1.95.7**.

The detection works by extracting the version number from the script tag:

```html
<script src="https://unpkg.com/@solana/web3.js@1.95.8/lib/index.iife.min.js"></script>
```
It then compares the extracted version to a range of vulnerable versions, currently [1.95.6, 1.95.7]. If the version matches any in the range, the vulnerability will be reported.