### PR TITLE
Feature/CVE 2024 50623

### DIFF
--- a/agent/exploits/cve_2024_50623.py
+++ b/agent/exploits/cve_2024_50623.py
@@ -1,0 +1,43 @@
+"""Agent Asteroid implementation for CVE-2024-50623"""
+
+import re
+from packaging import version
+
+from agent import definitions
+from agent import exploits_registry
+from agent.exploits import webexploit
+
+VERSION_PATTERN = re.compile(
+    r"(?:VLTrader|Harmony|LexiCom)/((?:[0-4](?:\.\d+){0,3})|5(?:\.[0-7](?:\.\d{1,2}){0,2})?|5\.8(?:\.0(?:\.(?:0|[1-9]|1[0-9]|2[0-1]))?)?)\s*\("
+)
+MAX_VULNERABLE_VERSION = version.parse("5.8.0.21")
+MIN_VULNERABLE_VERSION = version.parse("0.0.0")  # No minimum version specified
+VULNERABILITY_TITLE = (
+    "Cleo Harmony, VLTrader, and LexiCom - Unrestricted File Upload and Download "
+    "Leading to Remote Code Execution"
+)
+VULNERABILITY_REFERENCE = "CVE-2024-50623"
+VULNERABILITY_DESCRIPTION = (
+    "In Cleo Harmony before 5.8.0.21, VLTrader before 5.8.0.21, and LexiCom before "
+    "5.8.0.21, there is an unrestricted file upload and download vulnerability. "
+    "Exploitation of this issue could lead to remote code execution."
+)
+RISK_RATING = "CRITICAL"
+
+
+@exploits_registry.register
+class CVE202450623Exploit(webexploit.WebExploit):
+    accept_request = definitions.Request(method="GET", path="/")
+    check_request = definitions.Request(method="GET", path="/")
+    accept_pattern = [re.compile(r"Cleo (VLTrader|Harmony|LexiCom)/[\d.]+")]
+    version_pattern = VERSION_PATTERN
+    vuln_ranges = [
+        definitions.VulnRange(MIN_VULNERABLE_VERSION, MAX_VULNERABLE_VERSION)
+    ]
+
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+    )

--- a/agent/exploits/cve_2024_50623.py
+++ b/agent/exploits/cve_2024_50623.py
@@ -11,7 +11,7 @@ VERSION_PATTERN = re.compile(
     r"(?:VLTrader|Harmony|LexiCom)/((?:[0-4](?:\.\d+){0,3})|5(?:\.[0-7](?:\.\d{1,2}){0,2})?|5\.8(?:\.0(?:\.(?:0|[1-9]|1[0-9]|2[0-1]))?)?)\s*\("
 )
 MAX_VULNERABLE_VERSION = version.parse("5.8.0.21")
-MIN_VULNERABLE_VERSION = version.parse("0.0.0")  # No minimum version specified
+MIN_VULNERABLE_VERSION = version.parse("0.0.0")
 VULNERABILITY_TITLE = (
     "Cleo Harmony, VLTrader, and LexiCom - Unrestricted File Upload and Download "
     "Leading to Remote Code Execution"

--- a/agent/exploits/cve_2024_50623.py
+++ b/agent/exploits/cve_2024_50623.py
@@ -1,6 +1,7 @@
 """Agent Asteroid implementation for CVE-2024-50623"""
 
 import re
+
 from packaging import version
 
 from agent import definitions

--- a/agent/exploits/webexploit.py
+++ b/agent/exploits/webexploit.py
@@ -20,6 +20,7 @@ class WebExploit(definitions.Exploit):
     check_request: definitions.Request
     accept_pattern: list[re.Pattern[str]] = []
     match_pattern: list[re.Pattern[str]] = []
+    header_name: str
     vuln_ranges: list[definitions.VulnRange] = []
     metadata: definitions.VulnerabilityMetadata
     version_pattern: re.Pattern[str] | None = None
@@ -52,7 +53,10 @@ class WebExploit(definitions.Exploit):
             return False
 
         for pattern in self.accept_pattern:
-            if pattern.search(resp.text) is not None:
+            if (
+                pattern.search(resp.text) is not None
+                or pattern.search(str(resp.headers)) is not None
+            ):
                 return True
         return False
 
@@ -86,14 +90,24 @@ class WebExploit(definitions.Exploit):
             return vulnerabilities
 
         for pattern in self.match_pattern:
-            if pattern.search(resp.text) is not None:
+            if (
+                pattern.search(resp.text) is not None
+                or pattern.search(str(resp.headers)) is not None
+            ):
                 vulnerability = self._create_vulnerability(target)
                 vulnerabilities.append(vulnerability)
                 return vulnerabilities
 
         if self.vuln_ranges is not None:
             if self.version_pattern is not None:
-                if (matched := self.version_pattern.findall(resp.text)) is not None:
+                if (
+                    self.version_pattern.findall(resp.text)
+                ) is not None or self.version_pattern.findall(
+                    str(resp.headers)
+                ) is not None:
+                    matched = self.version_pattern.findall(
+                        resp.text
+                    ) or self.version_pattern.findall(str(resp.headers))
                     for extracted_version in matched:
                         if isinstance(extracted_version, tuple):
                             extracted_version = extracted_version[0]

--- a/agent/exploits/webexploit.py
+++ b/agent/exploits/webexploit.py
@@ -53,9 +53,8 @@ class WebExploit(definitions.Exploit):
             return False
 
         for pattern in self.accept_pattern:
-            if (
-                pattern.search(resp.text) is not None
-                or pattern.search(str(resp.headers)) is not None
+            if pattern.search(resp.text) is not None or (
+                len(resp.headers) > 0 and pattern.search(str(resp.headers)) is not None
             ):
                 return True
         return False
@@ -90,9 +89,8 @@ class WebExploit(definitions.Exploit):
             return vulnerabilities
 
         for pattern in self.match_pattern:
-            if (
-                pattern.search(resp.text) is not None
-                or pattern.search(str(resp.headers)) is not None
+            if pattern.search(resp.text) is not None or (
+                len(resp.headers) > 0 and pattern.search(str(resp.headers)) is not None
             ):
                 vulnerability = self._create_vulnerability(target)
                 vulnerabilities.append(vulnerability)

--- a/agent/exploits/webexploit.py
+++ b/agent/exploits/webexploit.py
@@ -20,7 +20,6 @@ class WebExploit(definitions.Exploit):
     check_request: definitions.Request
     accept_pattern: list[re.Pattern[str]] = []
     match_pattern: list[re.Pattern[str]] = []
-    header_name: str
     vuln_ranges: list[definitions.VulnRange] = []
     metadata: definitions.VulnerabilityMetadata
     version_pattern: re.Pattern[str] | None = None

--- a/tests/exploits/cve_2024_50623_test.py
+++ b/tests/exploits/cve_2024_50623_test.py
@@ -1,0 +1,76 @@
+"""Unit tests for Agent Asteroid: CVE-2024-50623"""
+
+"""Unit tests for Agent Asteroid: CVE-2024-50623"""
+
+import requests_mock as req_mock
+from ostorlab.agent.mixins import agent_report_vulnerability_mixin as vuln_mixin
+
+from agent import definitions
+from agent.exploits import cve_2024_50623
+
+
+def testCVE202450623_whenVulnerable_reportFinding(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-50623 unit test: case when target is vulnerable."""
+    requests_mock.get(
+        "http://localhost:80/",
+        text="Cleo VLTrader/5.8.0.20 (Build 12345)",
+        status_code=200,
+    )
+    exploit_instance = cve_2024_50623.CVE202450623Exploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) > 0
+    vulnerability = vulnerabilities[0]
+    assert (
+        vulnerability.entry.title
+        == "Cleo Harmony, VLTrader, and LexiCom - Unrestricted File Upload and Download Leading to Remote Code Execution"
+    )
+    assert vulnerability.technical_detail == (
+        "http://localhost:80 is vulnerable to CVE-2024-50623, Cleo Harmony, VLTrader, and LexiCom -"
+        " Unrestricted File Upload and Download Leading to Remote Code Execution"
+    )
+    assert vulnerability.risk_rating == vuln_mixin.RiskRating.CRITICAL
+
+
+def testCVE202450623_whenSafe_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-50623 unit test: case when target is safe."""
+    requests_mock.get(
+        "http://localhost:80/",
+        text="Cleo VLTrader/5.8.0.22 (Build 12345)",
+        status_code=200,
+    )
+    exploit_instance = cve_2024_50623.CVE202450623Exploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is True
+    assert len(vulnerabilities) == 0
+
+
+def testCVE202450623_whenTargetNotCleoProduct_reportNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """CVE-2024-50623 unit test: case when target is not a Cleo product."""
+    requests_mock.get(
+        "http://localhost:80/",
+        text="Not Found",
+        status_code=404,
+    )
+    exploit_instance = cve_2024_50623.CVE202450623Exploit()
+    target = definitions.Target("http", "localhost", 80)
+
+    accept = exploit_instance.accept(target)
+    vulnerabilities = exploit_instance.check(target)
+
+    assert accept is False
+    assert len(vulnerabilities) == 0

--- a/tests/exploits/cve_2024_50623_test.py
+++ b/tests/exploits/cve_2024_50623_test.py
@@ -1,7 +1,5 @@
 """Unit tests for Agent Asteroid: CVE-2024-50623"""
 
-"""Unit tests for Agent Asteroid: CVE-2024-50623"""
-
 import requests_mock as req_mock
 from ostorlab.agent.mixins import agent_report_vulnerability_mixin as vuln_mixin
 


### PR DESCRIPTION
The provided regular expression is used to extract version information for specific software products (VLTrader, Harmony, LexiCom) from a given text or response. Here's a detailed breakdown of the pattern:

### Explanation of the Regex
```
(?:VLTrader|Harmony|LexiCom)/
(
  (?:[0-4](?:\.\d+){0,3}) 
  | 
  5(?:\.[0-7](?:\.\d{1,2}){0,2})? 
  | 
  5\.8(?:\.0(?:\.(?:0|[1-9]|1[0-9]|2[0-1]))?)?
)
\s*\(
```
1 -Non-capturing group: (?:VLTrader|Harmony|LexiCom)

- The (?:...) syntax is a non-capturing group used here to match one of the product names (VLTrader, Harmony, LexiCom) without including the match in the captured output. This ensures we are only interested in capturing the version number, not the product name.

2 - Product delimiter: /

- Ensures that the version number follows the product name with a /.

3- Main capturing group:

- The (...) is a capturing group that isolates and retrieves the version number. The version format can be:
     - Versions starting with 0–4: (?:[0-4](?:\.\d+){0,3})
            - Matches version numbers like 1, 3.2, 4.1.2.3.
     - Versions starting with 5 up to 5.7: 5(?:\.[0-7](?:\.\d{1,2}){0,2})?
            - Matches versions like 5, 5.3, 5.7.2.12.
     - Version 5.8 with finer granularity: 5\.8(?:\.0(?:\.(?:0|[1-9]|1[0-9]|2[0-1]))?)?
            - Matches 5.8, 5.8.0, 5.8.0.21.
 - The | operator ensures all these subformats are considered.
4  - Optional whitespace and parentheses: \s*\(

- Matches any optional whitespace (\s*) and ensures the version number is followed by an opening parenthesis (().

### Purpose of ?:
The ?: inside the groups (e.g., (?:VLTrader|Harmony|LexiCom) and (?:[0-4](?:\.\d+){0,3})) creates non-capturing groups. This allows matching specific patterns without including them in the result. In this regex, ?: ensures that only the version number is captured and returned, avoiding unwanted matches for the product name or separators.

---------------------------

### Added Checks for Response Headers
In addition to checking the body of the HTTP response, checks were added to analyze the headers as well. 