### PR TITLE
Skip processed messages 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ MANIFEST
 # Per-project virtualenvs
 .venv*/
 .conda*/
+.aider*

--- a/agent/asteroid_agent.py
+++ b/agent/asteroid_agent.py
@@ -77,7 +77,7 @@ class AsteroidAgent(
                     key=ASTEROID_AGENT_KEY, ip_range=addresses
                 )
             return self.set_is_member(key=ASTEROID_AGENT_KEY, value=host)
-        logger.error("Unknown target %s", message)
+        logger.warning(f"Invalid message format\nmessage: {message}")
         return True
 
     def _mark_target_as_processed(self, message: m.Message) -> None:
@@ -93,8 +93,6 @@ class AsteroidAgent(
                 self.add_ip_network(key=ASTEROID_AGENT_KEY, ip_range=addresses)
             else:
                 self.set_add(ASTEROID_AGENT_KEY, host)
-        else:
-            logger.error("Unknown target %s", message)
 
     def process(self, message: m.Message) -> None:
         """Process messages of type `v3.asset.ip.[v4,v6]` or `v3.asset.[domain_name,link]` and performs a network

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -79,7 +79,6 @@ def testAsteroidAgent_whenDomainReceivedTwice_onlyProcessesOnce(
     asteroid_agent_instance: asteroid_agent.AsteroidAgent,
     scan_message_domain_name: m.Message,
     mocker: plugin.MockerFixture,
-    agent_persist_mock: dict[str | bytes, str | bytes],
 ) -> None:
     """Test that a message is only processed once and marked as processed."""
     targets_preparer_mock = mocker.patch(
@@ -102,7 +101,6 @@ def testAsteroidAgent_whenIPReceivedTwice_onlyProcessesOnce(
     asteroid_agent_instance: asteroid_agent.AsteroidAgent,
     scan_message_ipv4: m.Message,
     mocker: plugin.MockerFixture,
-    agent_persist_mock: dict[str | bytes, str | bytes],
 ) -> None:
     """Test that a message is only processed once and marked as processed."""
     targets_preparer_mock = mocker.patch(

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -1,5 +1,6 @@
 """Unit tests for AsteroidAgent."""
 
+import ipaddress
 from typing import Any, Iterator, Type
 
 import requests_mock
@@ -72,3 +73,50 @@ def testAsteroidAgent_whenTooManyRedirects_doesNotCrash(
 
     assert len(agent_mock) == 1
     assert agent_mock[0].selector == "v3.report.vulnerability"
+
+
+def testAsteroidAgent_whenDomainReceivedTwice_onlyProcessesOnce(
+    asteroid_agent_instance: asteroid_agent.AsteroidAgent,
+    scan_message_domain_name: m.Message,
+    mocker: plugin.MockerFixture,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+) -> None:
+    """Test that a message is only processed once and marked as processed."""
+    targets_preparer_mock = mocker.patch(
+        "agent.asteroid_agent.targets_preparer.prepare_targets"
+    )
+    asteroid_agent_instance.process(scan_message_domain_name)
+
+    asteroid_agent_instance.process(scan_message_domain_name)
+
+    assert targets_preparer_mock.call_count == 1
+    assert (
+        asteroid_agent_instance.set_is_member(
+            key=asteroid_agent.ASTEROID_AGENT_KEY, value="www.google.com"
+        )
+        is True
+    )
+
+
+def testAsteroidAgent_whenIPReceivedTwice_onlyProcessesOnce(
+    asteroid_agent_instance: asteroid_agent.AsteroidAgent,
+    scan_message_ipv4: m.Message,
+    mocker: plugin.MockerFixture,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+) -> None:
+    """Test that a message is only processed once and marked as processed."""
+    targets_preparer_mock = mocker.patch(
+        "agent.asteroid_agent.targets_preparer.prepare_targets"
+    )
+    asteroid_agent_instance.process(scan_message_ipv4)
+
+    asteroid_agent_instance.process(scan_message_ipv4)
+
+    assert targets_preparer_mock.call_count == 1
+    addresses = ipaddress.ip_network("192.168.1.17/32", strict=False)
+    assert (
+        asteroid_agent_instance.ip_network_exists(
+            key=asteroid_agent.ASTEROID_AGENT_KEY, ip_range=addresses
+        )
+        is True
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,9 @@ def scan_message_ipv6_with_mask64() -> message.Message:
 
 
 @pytest.fixture()
-def asteroid_agent_instance() -> asteroid_agent.AsteroidAgent:
+def asteroid_agent_instance(
+    agent_persist_mock: dict[str | bytes, str | bytes],
+) -> asteroid_agent.AsteroidAgent:
     with (pathlib.Path(__file__).parent.parent / "ostorlab.yaml").open() as yaml_o:
         definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
         settings = runtime_definitions.AgentSettings(


### PR DESCRIPTION
This PR prevents the agent from scanning the same target twice in the same scan by storing processed messages in the Redis database.

This ensures the agent does not redo the same work when integrated with other agents that emit network/domain targets.