### PR TITLE
Fix technical detail should contain origin not url.

### DIFF
--- a/agent/exploits/cve_2023_22518.py
+++ b/agent/exploits/cve_2023_22518.py
@@ -80,7 +80,7 @@ class CVE202322518Exploit(definitions.Exploit):
             return []
 
         if resp.status_code == 200:
-            vulnerability = self._create_vulnerability(target.url)
+            vulnerability = self._create_vulnerability(target.origin)
             return [vulnerability]
         else:
             return []

--- a/agent/exploits/cve_2023_36845.py
+++ b/agent/exploits/cve_2023_36845.py
@@ -59,7 +59,7 @@ class CVE202336845Exploit(definitions.Exploit):
         if PASSWD_PATTERN.search(resp.text) is None:
             return []
 
-        vulnerability = self._create_vulnerability(target.url)
+        vulnerability = self._create_vulnerability(target.origin)
         return [vulnerability]
 
     def _create_vulnerability(self, target_uri: str) -> definitions.Vulnerability:

--- a/agent/exploits/cve_2024_8522.py
+++ b/agent/exploits/cve_2024_8522.py
@@ -58,9 +58,7 @@ def _create_vulnerability(target: definitions.Target) -> definitions.Vulnerabili
         targeted_by_ransomware=False,
         targeted_by_nation_state=False,
     )
-    technical_detail = (
-        f"{target} is vulnerable to {VULNERABILITY_REFERENCE}, {VULNERABILITY_TITLE}"
-    )
+    technical_detail = f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, {VULNERABILITY_TITLE}"
     vulnerability = definitions.Vulnerability(
         entry=entry,
         technical_detail=technical_detail,

--- a/tests/exploits/cve_2023_22518_test.py
+++ b/tests/exploits/cve_2023_22518_test.py
@@ -30,7 +30,7 @@ def testCVE202322518_whenVulnerable_reportFinding(
         == "Improper Authorization Vulnerability In Confluence Data Center and Server"
     )
     assert vulnerability.technical_detail == (
-        "http://127.0.0.1:8090/ is vulnerable to CVE-2023-22518, Improper "
+        "http://127.0.0.1:8090 is vulnerable to CVE-2023-22518, Improper "
         "Authorization Vulnerability In Confluence Data Center and Server"
     )
     assert vulnerability.risk_rating.name == "CRITICAL"

--- a/tests/exploits/cve_2023_36845_test.py
+++ b/tests/exploits/cve_2023_36845_test.py
@@ -37,7 +37,7 @@ def testCVE202336845_whenVulnerable_reportFinding(
         == "Juniper Junos OS EX Series and SRX Series PHP External Variable Modification Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://127.0.0.1:8080/ is vulnerable to CVE-2023–36845, Juniper Junos OS "
+        "http://127.0.0.1:8080 is vulnerable to CVE-2023–36845, Juniper Junos OS "
         "EX Series and SRX Series PHP External Variable Modification Vulnerability"
     )
     assert vulnerability.risk_rating.name == "CRITICAL"

--- a/tests/exploits/cve_2024_8522_test.py
+++ b/tests/exploits/cve_2024_8522_test.py
@@ -143,3 +143,30 @@ def testCheck_whenTimeoutError_reportLoggedErrors(
 
         assert len(vulnerabilities) == 0
         assert "Timeout error" in caplog.text
+
+
+def testCve20248522_whenVulnerable_technicalDetailContainsOriginInsteadOfUrl(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """Test the check method when the target is vulnerable to SQL Injection."""
+    mock_response = mock.Mock()
+    mock_response.elapsed.total_seconds.return_value = 11
+    requests_mock.get(
+        "http://example.com:80/wp-json/learnpress/v1/courses", text="", status_code=200
+    )
+
+    with mock.patch("agent.definitions.HttpSession.get", return_value=mock_response):
+        exploit_instance = cve_2024_8522.LearnPressSQLInjectionExploit()
+        target = definitions.Target("http", "example.com", 80)
+
+        vulnerabilities = exploit_instance.check(target)
+
+        assert len(vulnerabilities) == 1
+        assert (
+            vulnerabilities[0].entry.title
+            == "Unauthenticated SQL Injection Vulnerability in LearnPress Plugin"
+        )
+        assert (
+            vulnerabilities[0].technical_detail
+            == "http://example.com:80 is vulnerable to CVE-2024-8522, Unauthenticated SQL Injection Vulnerability in LearnPress Plugin"
+        )


### PR DESCRIPTION
## Fix: Use `target.origin` Instead of `target.url` in Technical Details  

### Summary  
This PR updates the code to use `target.origin` instead of `target.url` in the **technical detail** field. This ensures consistency in vulnerability reporting and prevents issues caused by different paths on the same host.  

### Problem  
Previously, the technical detail field used `target.url`, which included the full path. Since DNA computation relies on the technical detail (along with title and vulnerability location), different paths on the same host resulted in different DNA hashes.

### Solution  
- Replaced `target.url` with `target.origin` in the technical detail field.  
- This ensures vulnerabilities are correctly grouped by origin rather than individual paths.  

