### PR TITLE
Fix technical detail should contain url not origin.

### DIFF
--- a/agent/exploits/cve_2014_0780.py
+++ b/agent/exploits/cve_2014_0780.py
@@ -78,7 +78,7 @@ class CVE20140780Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2014_7169.py
+++ b/agent/exploits/cve_2014_7169.py
@@ -60,12 +60,10 @@ class CVE20147169Exploit(definitions.Exploit):
             if elapsed < delay or elapsed - delay > MAX_DELAY_DIFFERENCE:
                 return []
 
-        vulnerability = self._generate_vulnerability_object(target.url)
+        vulnerability = self._create_vulnerability(target.url)
         return [vulnerability]
 
-    def _generate_vulnerability_object(
-        self, target_uri: str
-    ) -> definitions.Vulnerability:
+    def _create_vulnerability(self, target_uri: str) -> definitions.Vulnerability:
         entry = kb.Entry(
             title=VULNERABILITY_TITLE,
             risk_rating="CRITICAL",

--- a/agent/exploits/cve_2016_2386.py
+++ b/agent/exploits/cve_2016_2386.py
@@ -75,7 +75,7 @@ class CVE20162386Exploit(definitions.Exploit):
             return []
 
         if resp.status_code == 200 and PERMISSION_KEYWORD in resp.text:
-            vulnerability = self._create_vulnerability(target.origin)
+            vulnerability = self._create_vulnerability(target.url)
             return [vulnerability]
 
         return []

--- a/agent/exploits/cve_2018_10561.py
+++ b/agent/exploits/cve_2018_10561.py
@@ -55,12 +55,10 @@ class CVE201810562Exploit(definitions.Exploit):
         if "diag_result" not in response.text:
             return []
 
-        vulnerability = self._generate_vulnerability_object(
-            target.origin, response.text
-        )
+        vulnerability = self._create_vulnerability(target.url, response.text)
         return [vulnerability]
 
-    def _generate_vulnerability_object(
+    def _create_vulnerability(
         self, target_uri: str, response_body: str
     ) -> definitions.Vulnerability:
         entry = kb.Entry(

--- a/agent/exploits/cve_2018_13382.py
+++ b/agent/exploits/cve_2018_13382.py
@@ -91,7 +91,7 @@ class CVE201813382Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to CVE-2018-13382 : the admin user's"
+            f"{target.url} is vulnerable to CVE-2018-13382 : the admin user's"
             f" password being changed to `ChangePassword`."
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2018_14558.py
+++ b/agent/exploits/cve_2018_14558.py
@@ -46,12 +46,10 @@ class CVE201814558Exploit(definitions.Exploit):
             if elapsed < delay or elapsed - delay > MAX_DELAY_DIFFERENCE:
                 return []
 
-        vulnerability = self._generate_vulnerability_object(target.origin)
+        vulnerability = self._create_vulnerability(target.url)
         return [vulnerability]
 
-    def _generate_vulnerability_object(
-        self, target_uri: str
-    ) -> definitions.Vulnerability:
+    def _create_vulnerability(self, target_uri: str) -> definitions.Vulnerability:
         entry = kb.Entry(
             title=VULNERABILITY_TITLE,
             risk_rating="CRITICAL",

--- a/agent/exploits/cve_2018_14667.py
+++ b/agent/exploits/cve_2018_14667.py
@@ -62,7 +62,7 @@ class CVE201814667Exploit(definitions.Exploit):
             return []
         target_version = version.parse(version_match.group(1).replace("_", "."))
         if target_version <= UPPER_VULNERABLE_VERSION:
-            vulnerability = self._create_vulnerability(target.origin)
+            vulnerability = self._create_vulnerability(target.url)
             return [vulnerability]
         else:
             return []

--- a/agent/exploits/cve_2018_15133.py
+++ b/agent/exploits/cve_2018_15133.py
@@ -91,7 +91,7 @@ class CVE201815133Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2018_7841.py
+++ b/agent/exploits/cve_2018_7841.py
@@ -50,7 +50,7 @@ class CVE20187841Exploit(definitions.Exploit):
             if elapsed < delay or elapsed - delay > MAX_DELAY_DIFFERENCE:
                 return []
 
-        vulnerability = self._create_vulnerability(target.origin)
+        vulnerability = self._create_vulnerability(target.url)
         return [vulnerability]
 
     def _create_vulnerability(self, target_uri: str) -> definitions.Vulnerability:

--- a/agent/exploits/cve_2019_12989.py
+++ b/agent/exploits/cve_2019_12989.py
@@ -108,7 +108,7 @@ class CVE201912989Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to CVE-2019-12989 and CVE-2019-12991"
+            f"{target.url} is vulnerable to CVE-2019-12989 and CVE-2019-12991"
         )
         vulnerability = definitions.Vulnerability(
             entry=entry,

--- a/agent/exploits/cve_2019_7193.py
+++ b/agent/exploits/cve_2019_7193.py
@@ -91,7 +91,7 @@ class CVE20197193Exploit(definitions.Exploit):
         if b"/bin/sh" not in resp.content:
             return []
 
-        vulnerability = self._create_vulnerability(target.origin)
+        vulnerability = self._create_vulnerability(target.url)
         return [vulnerability]
 
     def _create_vulnerability(self, target_uri: str) -> definitions.Vulnerability:

--- a/agent/exploits/cve_2020_2551.py
+++ b/agent/exploits/cve_2020_2551.py
@@ -127,7 +127,7 @@ class CVE20202551Exploit(definitions.Exploit):
         except TimeoutError:
             # If the target is vulnerable, it'll try to lookup the address in JRMP
             # The port in that address is most likely closed, hence the request will timeout
-            vulnerability = self._create_vulnerability(target.origin)
+            vulnerability = self._create_vulnerability(target.url)
             return [vulnerability]
         except socket.error:
             return []

--- a/agent/exploits/cve_2021_22941.py
+++ b/agent/exploits/cve_2021_22941.py
@@ -70,7 +70,7 @@ class CVE20212941Exploit(definitions.Exploit):
         if payload not in req.text:
             return []
 
-        vulnerability = self._create_vulnerability(target.origin)
+        vulnerability = self._create_vulnerability(target.url)
         return [vulnerability]
 
     def _create_vulnerability(self, target_uri: str) -> definitions.Vulnerability:

--- a/agent/exploits/cve_2021_32648.py
+++ b/agent/exploits/cve_2021_32648.py
@@ -46,7 +46,7 @@ class CVE202132648Exploit(definitions.Exploit):
             and self._set_password(target.origin) is True
             and self._login_attempt(target.origin) is True
         ):
-            vulnerability = self._generate_vulnerability_object(target)
+            vulnerability = self._create_vulnerability(target)
             return [vulnerability]
 
         return []
@@ -137,7 +137,7 @@ class CVE202132648Exploit(definitions.Exploit):
                 return True
         return False
 
-    def _generate_vulnerability_object(
+    def _create_vulnerability(
         self, target: definitions.Target
     ) -> definitions.Vulnerability:
         entry = kb.Entry(
@@ -168,7 +168,7 @@ class CVE202132648Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to CVE-2021-32648: the admin user's"
+            f"{target.url} is vulnerable to CVE-2021-32648: the admin user's"
             f" password being changed to `ChangePassword`."
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2022_26318.py
+++ b/agent/exploits/cve_2022_26318.py
@@ -137,7 +137,7 @@ class CVE202226318Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2023_1389.py
+++ b/agent/exploits/cve_2023_1389.py
@@ -42,16 +42,14 @@ class CVE20231389Exploit(definitions.Exploit):
             )
             # TODO(OS-6117): Approximate check that needs a live instance to validate the issue.
             if response.status_code == 500:
-                vulnerability = self._generate_vulnerability_object(target.origin)
+                vulnerability = self._create_vulnerability(target.url)
                 return [vulnerability]
         except requests_exceptions.RequestException:
             return []
 
         return []
 
-    def _generate_vulnerability_object(
-        self, target_uri: str
-    ) -> definitions.Vulnerability:
+    def _create_vulnerability(self, target_uri: str) -> definitions.Vulnerability:
         entry = kb.Entry(
             title=VULNERABILITY_TITLE,
             risk_rating="CRITICAL",

--- a/agent/exploits/cve_2023_22518.py
+++ b/agent/exploits/cve_2023_22518.py
@@ -80,7 +80,7 @@ class CVE202322518Exploit(definitions.Exploit):
             return []
 
         if resp.status_code == 200:
-            vulnerability = self._create_vulnerability(target.origin)
+            vulnerability = self._create_vulnerability(target.url)
             return [vulnerability]
         else:
             return []

--- a/agent/exploits/cve_2023_27997.py
+++ b/agent/exploits/cve_2023_27997.py
@@ -125,7 +125,7 @@ class CVE202327997Exploit(definitions.Exploit):
         if t_stat.statistic < -0.5:
             return []
         elif t_stat.statistic > 0.5:
-            vulnerability = self._create_vulnerability(target.origin)
+            vulnerability = self._create_vulnerability(target.url)
             return [vulnerability]
         else:
             return []

--- a/agent/exploits/cve_2023_36845.py
+++ b/agent/exploits/cve_2023_36845.py
@@ -59,7 +59,7 @@ class CVE202336845Exploit(definitions.Exploit):
         if PASSWD_PATTERN.search(resp.text) is None:
             return []
 
-        vulnerability = self._create_vulnerability(target.origin)
+        vulnerability = self._create_vulnerability(target.url)
         return [vulnerability]
 
     def _create_vulnerability(self, target_uri: str) -> definitions.Vulnerability:

--- a/agent/exploits/cve_2023_43770.py
+++ b/agent/exploits/cve_2023_43770.py
@@ -98,7 +98,7 @@ class CVE202343770Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2023_48788.py
+++ b/agent/exploits/cve_2023_48788.py
@@ -105,7 +105,7 @@ class CVE202348788Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2023_49897.py
+++ b/agent/exploits/cve_2023_49897.py
@@ -102,7 +102,7 @@ class CVE202349897Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2024_20419.py
+++ b/agent/exploits/cve_2024_20419.py
@@ -60,7 +60,7 @@ def _create_vulnerability(target: definitions.Target) -> definitions.Vulnerabili
         targeted_by_nation_state=False,
     )
     technical_detail = (
-        f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}: "
+        f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}: "
         f"{VULNERABILITY_TITLE}"
     )
     return definitions.Vulnerability(

--- a/agent/exploits/cve_2024_21733.py
+++ b/agent/exploits/cve_2024_21733.py
@@ -102,7 +102,7 @@ class CVE202421733Exploit(definitions.Exploit):
             targeted_by_nation_state=False,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2024_21762.py
+++ b/agent/exploits/cve_2024_21762.py
@@ -110,7 +110,7 @@ Transfer-Encoding: chunked\r
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2024_23113.py
+++ b/agent/exploits/cve_2024_23113.py
@@ -228,7 +228,7 @@ def _create_vulnerability(
         targeted_by_nation_state=True,
     )
     technical_detail = (
-        f"{product} device at {target.origin} is running a vulnerable version: {'.'.join(map(str, version))}. "
+        f"{product} device at {target.url} is running a vulnerable version: {'.'.join(map(str, version))}. "
         f"This version is susceptible to CVE-2024-23113. Immediate action is required."
     )
     vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2024_23334.py
+++ b/agent/exploits/cve_2024_23334.py
@@ -85,7 +85,7 @@ class CVE202423334Exploit(definitions.Exploit):
             targeted_by_nation_state=False,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2024_38077.py
+++ b/agent/exploits/cve_2024_38077.py
@@ -124,7 +124,7 @@ def _create_vulnerability(target: definitions.Target) -> definitions.Vulnerabili
         targeted_by_nation_state=False,
     )
     technical_detail = (
-        f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}: "
+        f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}: "
         f"{VULNERABILITY_TITLE}"
     )
     return definitions.Vulnerability(

--- a/agent/exploits/cve_2024_4040.py
+++ b/agent/exploits/cve_2024_4040.py
@@ -82,7 +82,7 @@ class CVE20244040Exploit(definitions.Exploit):
             targeted_by_nation_state=True,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, "
+            f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, "
             f"{VULNERABILITY_TITLE}"
         )
         vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2024_40725.py
+++ b/agent/exploits/cve_2024_40725.py
@@ -173,7 +173,7 @@ def _create_vulnerability(target: definitions.Target) -> definitions.Vulnerabili
         targeted_by_ransomware=False,
         targeted_by_nation_state=False,
     )
-    technical_detail = f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}: {VULNERABILITY_TITLE}"
+    technical_detail = f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}: {VULNERABILITY_TITLE}"
     vulnerability = definitions.Vulnerability(
         entry=entry,
         technical_detail=technical_detail,

--- a/agent/exploits/cve_2024_40766.py
+++ b/agent/exploits/cve_2024_40766.py
@@ -81,7 +81,7 @@ def _create_vulnerability(
         targeted_by_nation_state=False,
     )
     technical_detail = (
-        f"SonicWall device at {target.origin} is running a vulnerable version: {version}. "
+        f"SonicWall device at {target.url} is running a vulnerable version: {version}. "
         f"Immediate action is required."
     )
     vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -121,7 +121,7 @@ def _create_vulnerability(
         targeted_by_nation_state=False,
     )
     technical_detail = (
-        f"HPE Aruba Networking Access Points device at {target.origin} is running a vulnerable version: {version}. "
+        f"HPE Aruba Networking Access Points device at {target.url} is running a vulnerable version: {version}. "
         f"Immediate action is required."
     )
     vulnerability = definitions.Vulnerability(

--- a/agent/exploits/cve_2024_6387.py
+++ b/agent/exploits/cve_2024_6387.py
@@ -135,7 +135,7 @@ def _create_vulnerability(
         targeted_by_ransomware=False,
         targeted_by_nation_state=False,
     )
-    technical_detail = f"Target: {target.origin}:{target.port}\nDetails: {details}"
+    technical_detail = f"Target: {target.url}\nDetails: {details}"
     vulnerability = definitions.Vulnerability(
         entry=entry,
         technical_detail=technical_detail,
@@ -176,7 +176,7 @@ class OpenSSHExploit(definitions.Exploit):
         """Checks the target for the specific vulnerability."""
         vulnerabilities = []
         if self.accept(target):
-            details = f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}: {VULNERABILITY_TITLE}"
+            details = f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}: {VULNERABILITY_TITLE}"
             vulnerability = _create_vulnerability(target, details)
             vulnerabilities.append(vulnerability)
         return vulnerabilities

--- a/agent/exploits/cve_2024_6633.py
+++ b/agent/exploits/cve_2024_6633.py
@@ -48,7 +48,7 @@ def _create_vulnerability(target: definitions.Target) -> definitions.Vulnerabili
         targeted_by_nation_state=False,
     )
     technical_detail = (
-        f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}: "
+        f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}: "
         f"{VULNERABILITY_TITLE}"
     )
     return definitions.Vulnerability(

--- a/agent/exploits/cve_2024_7120.py
+++ b/agent/exploits/cve_2024_7120.py
@@ -49,7 +49,7 @@ def _create_vulnerability(target: definitions.Target) -> definitions.Vulnerabili
         targeted_by_nation_state=False,
     )
     technical_detail = (
-        f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}: "
+        f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}: "
         f"{VULNERABILITY_TITLE}"
     )
     return definitions.Vulnerability(

--- a/agent/exploits/cve_2024_7589.py
+++ b/agent/exploits/cve_2024_7589.py
@@ -106,7 +106,7 @@ class OpenSSHExploit(definitions.Exploit):
         """Checks the target for the specific vulnerability."""
         vulnerabilities = []
         if self.accept(target) is True:
-            details = f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}: {VULNERABILITY_TITLE}"
+            details = f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}: {VULNERABILITY_TITLE}"
             vulnerability = _create_vulnerability(target, details)
             vulnerabilities.append(vulnerability)
         return vulnerabilities

--- a/agent/exploits/cve_2024_8522.py
+++ b/agent/exploits/cve_2024_8522.py
@@ -58,7 +58,7 @@ def _create_vulnerability(target: definitions.Target) -> definitions.Vulnerabili
         targeted_by_ransomware=False,
         targeted_by_nation_state=False,
     )
-    technical_detail = f"{target.origin} is vulnerable to {VULNERABILITY_REFERENCE}, {VULNERABILITY_TITLE}"
+    technical_detail = f"{target.url} is vulnerable to {VULNERABILITY_REFERENCE}, {VULNERABILITY_TITLE}"
     vulnerability = definitions.Vulnerability(
         entry=entry,
         technical_detail=technical_detail,

--- a/agent/exploits/cve_2024_8956.py
+++ b/agent/exploits/cve_2024_8956.py
@@ -76,7 +76,7 @@ class VHDPTZAuthBypassExploit(webexploit.WebExploit):
             targeted_by_nation_state=False,
         )
 
-        technical_detail = f"{target.origin} is vulnerable to {self.metadata.reference}, {self.metadata.title}"
+        technical_detail = f"{target.url} is vulnerable to {self.metadata.reference}, {self.metadata.title}"
         if details is not None:
             technical_detail += f"\n- {details}"
 

--- a/agent/exploits/exposed_adb.py
+++ b/agent/exploits/exposed_adb.py
@@ -69,10 +69,10 @@ class ExposedAdbExploit(definitions.Exploit):
         if command_output != KEYWORD:
             return []
 
-        vulnerability = self._generate_vulnerability_object(target)
+        vulnerability = self._create_vulnerability(target)
         return [vulnerability]
 
-    def _generate_vulnerability_object(
+    def _create_vulnerability(
         self, target: definitions.Target
     ) -> definitions.Vulnerability:
         entry = kb.Entry(

--- a/agent/exploits/exposed_adb.py
+++ b/agent/exploits/exposed_adb.py
@@ -97,9 +97,7 @@ class ExposedAdbExploit(definitions.Exploit):
             targeted_by_ransomware=True,
             targeted_by_nation_state=True,
         )
-        technical_detail = (
-            f"{target.host}:{target.port} is vulnerable to {VULNERABILITY_TITLE}."
-        )
+        technical_detail = f"{target.url} is vulnerable to {VULNERABILITY_TITLE}."
         vulnerability = definitions.Vulnerability(
             entry=entry,
             technical_detail=technical_detail,

--- a/agent/exploits/webexploit.py
+++ b/agent/exploits/webexploit.py
@@ -145,7 +145,7 @@ class WebExploit(definitions.Exploit):
             targeted_by_nation_state=False,
         )
         technical_detail = (
-            f"{target.origin} is vulnerable to {self.metadata.reference}, "
+            f"{target.url} is vulnerable to {self.metadata.reference}, "
             f"{self.metadata.title}"
         )
         vulnerability = definitions.Vulnerability(

--- a/tests/exploits/cve_2014_0780_test.py
+++ b/tests/exploits/cve_2014_0780_test.py
@@ -33,7 +33,7 @@ def testCVE20140780_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == "Indusoft Web Studio Directory Traversal."
     assert (
         vulnerability.technical_detail
-        == "http://8.8.8.8:80 is vulnerable to CVE-2014_0780, "
+        == "http://8.8.8.8:80/ is vulnerable to CVE-2014_0780, "
         "Indusoft Web Studio Directory Traversal."
     )
 

--- a/tests/exploits/cve_2014_2120_test.py
+++ b/tests/exploits/cve_2014_2120_test.py
@@ -43,7 +43,7 @@ def testCVE20142120_whenVulnerable_reportFinding(
     )
 
     exploit_instance = cve_2014_2120.CVE20142120XSSExploit()
-    target = definitions.Target("http", "localhost", 80)
+    target = definitions.Target("http", "localhost", 80, "/path/to/resource")
 
     vulnerabilities = exploit_instance.check(target)
 
@@ -51,7 +51,7 @@ def testCVE20142120_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "Cisco ASA WebVPN Login Page XSS Vulnerability"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2014-2120, Cisco ASA WebVPN Login Page XSS Vulnerability"
+        "http://localhost:80/path/to/resource is vulnerable to CVE-2014-2120, Cisco ASA WebVPN Login Page XSS Vulnerability"
     )
 
 

--- a/tests/exploits/cve_2016_2386_test.py
+++ b/tests/exploits/cve_2016_2386_test.py
@@ -29,7 +29,7 @@ def testCVE20162386_whenVulnerable_reportFinding(
     assert accept is True
     assert vulnerability.entry.title == "SAP NetWeaver SQL Injection Vulnerability"
     assert vulnerability.technical_detail == (
-        "http://127.0.0.1:50000 is vulnerable to CVE-2016-2386, SAP NetWeaver "
+        "http://127.0.0.1:50000/ is vulnerable to CVE-2016-2386, SAP NetWeaver "
         "SQL Injection Vulnerability"
     )
     assert vulnerability.risk_rating.name == "CRITICAL"

--- a/tests/exploits/cve_2018_10561_test.py
+++ b/tests/exploits/cve_2018_10561_test.py
@@ -28,7 +28,7 @@ def testCVE_2021_22941_whenVulnerable_reportFinding(
         == "Dasan GPON Routers Command Injection Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "https://75.162.65.52:443 is vulnerable to CVE-2018-10562, Dasan GPON Routers "
+        "https://75.162.65.52:443/ is vulnerable to CVE-2018-10562, Dasan GPON Routers "
         "Command Injection Vulnerability.\n"
         "```\n"
         "diag_result = test2.txt\n"

--- a/tests/exploits/cve_2018_13382_test.py
+++ b/tests/exploits/cve_2018_13382_test.py
@@ -28,7 +28,7 @@ def testCVE201813382_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "https://109.239.246.106:10443 is vulnerable to CVE-2018-13382 : "
+        == "https://109.239.246.106:10443/ is vulnerable to CVE-2018-13382 : "
         "the admin user's password being changed to `ChangePassword`."
     )
 

--- a/tests/exploits/cve_2018_14558_test.py
+++ b/tests/exploits/cve_2018_14558_test.py
@@ -33,7 +33,7 @@ def testCVE201814558_whenVulnerable_reportFinding(mocker: plugin.MockerFixture) 
         == "Tenda AC7, AC9, and AC10 Routers Command Injection Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "https://127.0.0.1:443 is vulnerable to "
+        "https://127.0.0.1:443/ is vulnerable to "
         "CVE-2018-14558, Tenda AC7, AC9, and AC10 Routers Command Injection "
         "Vulnerability."
     )

--- a/tests/exploits/cve_2018_14667_test.py
+++ b/tests/exploits/cve_2018_14667_test.py
@@ -35,7 +35,7 @@ def testCVE201814667_whenVulnerable_reportFinding(
         == "Red Hat JBoss RichFaces Framework Expression Language Injection Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://127.0.0.1:8081 is vulnerable to CVE-2018-14667, Red Hat JBoss "
+        "http://127.0.0.1:8081/ is vulnerable to CVE-2018-14667, Red Hat JBoss "
         "RichFaces Framework Expression Language Injection Vulnerability"
     )
     assert vulnerability.risk_rating.name == "CRITICAL"

--- a/tests/exploits/cve_2018_14933_test.py
+++ b/tests/exploits/cve_2018_14933_test.py
@@ -34,7 +34,7 @@ def testCVE201814933_whenVulnerable_reportFinding(
         vulnerability.entry.title == "Remote Command Execution in NUUO NVRmini devices"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2018-14933, Remote Command Execution in NUUO NVRmini devices"
+        "http://localhost:80/ is vulnerable to CVE-2018-14933, Remote Command Execution in NUUO NVRmini devices"
     )
     assert vulnerability.risk_rating == vuln_mixin.RiskRating.CRITICAL
 

--- a/tests/exploits/cve_2018_15133_test.py
+++ b/tests/exploits/cve_2018_15133_test.py
@@ -29,7 +29,7 @@ def testCVE201815133_whenVulnerable_reportFinding(
         "Command Execution"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:8089 is vulnerable to CVE-2018-15133, PHP Laravel "
+        "http://localhost:8089/ is vulnerable to CVE-2018-15133, PHP Laravel "
         "Framework 5.5.40 / 5.6.x < 5.6.30 - token Unserialize Remote Command "
         "Execution"
     )

--- a/tests/exploits/cve_2018_19410_test.py
+++ b/tests/exploits/cve_2018_19410_test.py
@@ -60,6 +60,10 @@ def testPRTGAuthBypassExploit_whenUserCreationSucceeds_reportsVulnerability(
         == "PRTG Network Monitor Authentication Bypass & Local File Inclusion"
     )
     assert vulnerabilities[0].risk_rating.name == "CRITICAL"
+    assert (
+        vulnerabilities[0].technical_detail
+        == "https://127.0.0.1:4433/ is vulnerable to CVE-2018-19410, PRTG Network Monitor Authentication Bypass & Local File Inclusion"
+    )
 
 
 def testPRTGAuthBypassExploit_whenUserCreationFails_reportsNothing(

--- a/tests/exploits/cve_2018_7841_test.py
+++ b/tests/exploits/cve_2018_7841_test.py
@@ -35,7 +35,7 @@ def testCVE20187841_whenVulnerable_reportFinding(mocker: plugin.MockerFixture) -
         == "Schneider Electric U.motion Builder SQL Injection Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "https://127.0.0.1:443 is vulnerable to CVE-2018-7841, Schneider Electric "
+        "https://127.0.0.1:443/ is vulnerable to CVE-2018-7841, Schneider Electric "
         "U.motion Builder SQL Injection Vulnerability"
     )
     assert vulnerability.risk_rating.name == "CRITICAL"

--- a/tests/exploits/cve_2019_12989_cve_2019_12997_test.py
+++ b/tests/exploits/cve_2019_12989_cve_2019_12997_test.py
@@ -31,7 +31,7 @@ def testCVE201912989_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "http://213.174.110.201:80 is vulnerable to CVE-2019-12989 and CVE-2019-12991"
+        == "http://213.174.110.201:80/ is vulnerable to CVE-2019-12989 and CVE-2019-12991"
     )
 
 

--- a/tests/exploits/cve_2019_16278_test.py
+++ b/tests/exploits/cve_2019_16278_test.py
@@ -32,7 +32,7 @@ def testCVE201916278_whenVulnerable_reportFinding(
         vulnerability.entry.title == "NOSTROMO NHTTPD DIRECTORY TRAVERSAL VULNERABILITY"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2019-16278, NOSTROMO NHTTPD DIRECTORY TRAVERSAL VULNERABILITY"
+        "http://localhost:80/ is vulnerable to CVE-2019-16278, NOSTROMO NHTTPD DIRECTORY TRAVERSAL VULNERABILITY"
     )
 
 

--- a/tests/exploits/cve_2019_7193_test.py
+++ b/tests/exploits/cve_2019_7193_test.py
@@ -35,7 +35,7 @@ def testCVE20197193_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "https://127.0.0.1:443 is vulnerable to CVE-2019-7193, "
+        == "https://127.0.0.1:443/ is vulnerable to CVE-2019-7193, "
         "QNAP QTS Improper Input Validation Vulnerability"
     )
     assert vulnerability.risk_rating.name == "CRITICAL"

--- a/tests/exploits/cve_2020_14644_test.py
+++ b/tests/exploits/cve_2020_14644_test.py
@@ -29,7 +29,7 @@ def testCVE202014644_whenVulnerable_reportFinding(
         vulnerability.entry.title == "WebLogic Remote Command Execution Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:7001 is vulnerable to CVE-2020-14644, WebLogic Remote Command Execution "
+        "http://localhost:7001/ is vulnerable to CVE-2020-14644, WebLogic Remote Command Execution "
         "Vulnerability"
     )
 

--- a/tests/exploits/cve_2020_15415_test.py
+++ b/tests/exploits/cve_2020_15415_test.py
@@ -34,7 +34,7 @@ def testCVE202015415_whenVulnerable_reportFinding(
         vulnerability.entry.title == "Remote Command Execution in DrayTek Vigor Routers"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2020-15415, "
+        "http://localhost:80/ is vulnerable to CVE-2020-15415, "
         "Remote Command Execution in DrayTek Vigor Routers"
     )
 

--- a/tests/exploits/cve_2020_2551_test.py
+++ b/tests/exploits/cve_2020_2551_test.py
@@ -37,7 +37,7 @@ def testCVE20202551_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == "Unauthenticated RCE In Oracle WebLogic"
     assert vulnerability.risk_rating.name == "CRITICAL"
     assert vulnerability.technical_detail == (
-        "http://127.0.0.1:80 is vulnerable to CVE-2020-2551, Unauthenticated RCE "
+        "http://127.0.0.1:80/ is vulnerable to CVE-2020-2551, Unauthenticated RCE "
         "In Oracle WebLogic"
     )
 

--- a/tests/exploits/cve_2021_22941_test.py
+++ b/tests/exploits/cve_2021_22941_test.py
@@ -37,6 +37,6 @@ def testCVE_2021_22941_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "https://75.162.65.52:443 is vulnerable to CVE-2021-22941, Improper Access Control "
+        == "https://75.162.65.52:443/ is vulnerable to CVE-2021-22941, Improper Access Control "
         "in Citrix ShareFile storage zones controller."
     )

--- a/tests/exploits/cve_2021_32648_test.py
+++ b/tests/exploits/cve_2021_32648_test.py
@@ -34,7 +34,7 @@ def testCVE202132648_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "https://68.183.191.108:443 is vulnerable to CVE-2021-32648: the admin user's "
+        == "https://68.183.191.108:443/ is vulnerable to CVE-2021-32648: the admin user's "
         "password being changed to `ChangePassword`."
     )
 

--- a/tests/exploits/cve_2021_40655_test.py
+++ b/tests/exploits/cve_2021_40655_test.py
@@ -37,7 +37,7 @@ def testCVE202140655E_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "http://localhost:8000 is vulnerable to CVE-2021-40655, Information disclosure issue exists in "
+        == "http://localhost:8000/ is vulnerable to CVE-2021-40655, Information disclosure issue exists in "
         "D-LINK-DIR-605 B2"
     )
 

--- a/tests/exploits/cve_2022_21445_test.py
+++ b/tests/exploits/cve_2022_21445_test.py
@@ -74,7 +74,7 @@ def testOracleADFExploit_whenVulnerable_reportFinding(
         == "Oracle Application Development Framework (ADF) Remote Code Execution Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:7001 is vulnerable to CVE-2022-21445, Oracle Application Development Framework (ADF) Remote "
+        "http://localhost:7001/ is vulnerable to CVE-2022-21445, Oracle Application Development Framework (ADF) Remote "
         "Code Execution Vulnerability"
     )
 

--- a/tests/exploits/cve_2022_26318_test.py
+++ b/tests/exploits/cve_2022_26318_test.py
@@ -25,7 +25,7 @@ def testCVE202226318_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "https://example.com:8080 is vulnerable to CVE-2022-26318, "
+        == "https://example.com:8080/ is vulnerable to CVE-2022-26318, "
         "WatchGuard Firebox and XTM Appliances Arbitrary Code Execution"
     )
 

--- a/tests/exploits/cve_2023_1389_test.py
+++ b/tests/exploits/cve_2023_1389_test.py
@@ -33,7 +33,7 @@ def testCVE20231389_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == "Remote Code Execution in TP-Link AX21"
     assert (
         vulnerability.technical_detail
-        == "https://109.239.246.106:10443 is vulnerable to CVE-2023-1389, Remote Code Execution in TP-Link AX21."
+        == "https://109.239.246.106:10443/ is vulnerable to CVE-2023-1389, Remote Code Execution in TP-Link AX21."
     )
     assert vulnerability.risk_rating.name == "POTENTIALLY"
 

--- a/tests/exploits/cve_2023_22518_test.py
+++ b/tests/exploits/cve_2023_22518_test.py
@@ -30,7 +30,7 @@ def testCVE202322518_whenVulnerable_reportFinding(
         == "Improper Authorization Vulnerability In Confluence Data Center and Server"
     )
     assert vulnerability.technical_detail == (
-        "http://127.0.0.1:8090 is vulnerable to CVE-2023-22518, Improper "
+        "http://127.0.0.1:8090/ is vulnerable to CVE-2023-22518, Improper "
         "Authorization Vulnerability In Confluence Data Center and Server"
     )
     assert vulnerability.risk_rating.name == "CRITICAL"

--- a/tests/exploits/cve_2023_25280_test.py
+++ b/tests/exploits/cve_2023_25280_test.py
@@ -32,7 +32,7 @@ def testCVE202325280_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "Command Injection in D-Link DIR820LA1"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2023-25280, "
+        "http://localhost:80/ is vulnerable to CVE-2023-25280, "
         "Command Injection in D-Link DIR820LA1"
     )
 

--- a/tests/exploits/cve_2023_27997_test.py
+++ b/tests/exploits/cve_2023_27997_test.py
@@ -40,7 +40,7 @@ def testCVE_2023_27997_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "https://91.135.170.42:8443 is vulnerable to CVE-2023-27997, "
+        == "https://91.135.170.42:8443/ is vulnerable to CVE-2023-27997, "
         "A heap-based buffer overflow vulnerability in FortiOS."
     )
     assert vulnerability.entry.risk_rating == "CRITICAL"

--- a/tests/exploits/cve_2023_28461_test.py
+++ b/tests/exploits/cve_2023_28461_test.py
@@ -62,7 +62,7 @@ def testCVE202328461_whenVulnerable_reportFinding(
         )
         assert (
             vulnerability.technical_detail
-            == "http://localhost:80 is vulnerable to CVE-2023-28461, Array Networks Array AG Series and vxAG Remote Code Execution Vulnerability"
+            == "http://localhost:80/ is vulnerable to CVE-2023-28461, Array Networks Array AG Series and vxAG Remote Code Execution Vulnerability"
         )
 
 

--- a/tests/exploits/cve_2023_34990_test.py
+++ b/tests/exploits/cve_2023_34990_test.py
@@ -39,7 +39,7 @@ def testCVE202334990_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == cve_2023_34990.VULNERABILITY_TITLE
     assert vulnerability.entry.risk_rating == "CRITICAL"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2023-34990, FortiWLM Directory Traversal"
+        "http://localhost:80/ is vulnerable to CVE-2023-34990, FortiWLM Directory Traversal"
     )
     mock_fetch_log_file.assert_called_once_with(
         "http://localhost:80/ems/cgi-bin/ezrf_lighttpd.cgi?op_type=upgradelogs&imagename=../../../../../../../../../data/apps/nms/logs/httpd_error_log"

--- a/tests/exploits/cve_2023_36845_test.py
+++ b/tests/exploits/cve_2023_36845_test.py
@@ -37,7 +37,7 @@ def testCVE202336845_whenVulnerable_reportFinding(
         == "Juniper Junos OS EX Series and SRX Series PHP External Variable Modification Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://127.0.0.1:8080 is vulnerable to CVE-2023–36845, Juniper Junos OS "
+        "http://127.0.0.1:8080/ is vulnerable to CVE-2023–36845, Juniper Junos OS "
         "EX Series and SRX Series PHP External Variable Modification Vulnerability"
     )
     assert vulnerability.risk_rating.name == "CRITICAL"

--- a/tests/exploits/cve_2023_43770_test.py
+++ b/tests/exploits/cve_2023_43770_test.py
@@ -39,7 +39,7 @@ def testCVE202343770_whenVulnerable_reportFinding(
         == "Roundcube Webmail Persistent Cross-Site Scripting (XSS) Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "https://localhost:443 is vulnerable to CVE-2023-43770, Roundcube "
+        "https://localhost:443/ is vulnerable to CVE-2023-43770, Roundcube "
         "Webmail Persistent Cross-Site Scripting (XSS) Vulnerability"
     )
 

--- a/tests/exploits/cve_2023_45727_test.py
+++ b/tests/exploits/cve_2023_45727_test.py
@@ -31,7 +31,7 @@ def testCVE202345727_whenVulnerable_reportFinding(
     assert accept is True
     assert vulnerability.entry.title == "Proself Enterprise/Standard XXE Vulnerability"
     assert vulnerability.technical_detail == (
-        "http://127.0.0.1:8080 is vulnerable to CVE-2023-45727, "
+        "http://127.0.0.1:8080/ is vulnerable to CVE-2023-45727, "
         "Proself Enterprise/Standard XXE Vulnerability"
     )
     assert vulnerability.risk_rating.name == "CRITICAL"

--- a/tests/exploits/cve_2023_48788_test.py
+++ b/tests/exploits/cve_2023_48788_test.py
@@ -43,7 +43,7 @@ def testCVE202348788_whenVulnerable_reportFinding(
         == "Fortinet FortiClient EMS SQL Injection Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "https://localhost:443 is vulnerable to CVE-2023-48788, Fortinet "
+        "https://localhost:443/ is vulnerable to CVE-2023-48788, Fortinet "
         "FortiClient EMS SQL Injection Vulnerability"
     )
 

--- a/tests/exploits/cve_2023_49897_test.py
+++ b/tests/exploits/cve_2023_49897_test.py
@@ -56,7 +56,7 @@ def testCVE2023_49897_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "http://8.8.8.8:9200 is vulnerable to CVE-2023-49897, "
+        == "http://8.8.8.8:9200/ is vulnerable to CVE-2023-49897, "
         'FXC wireless LAN routers "AE1021PE" and "AE1021" vulnerable to OS command injection.'
     )
 

--- a/tests/exploits/cve_2023_50969_test.py
+++ b/tests/exploits/cve_2023_50969_test.py
@@ -36,7 +36,7 @@ def testCVE202350969_whenVulnerable_reportFinding(
         == "Imperva SecureSphere WAF Bypass for POST Data Inspection Rules"
     )
     assert vulnerability.technical_detail == (
-        "https://localhost:443 is vulnerable to CVE-2023-50969, Imperva SecureSphere "
+        "https://localhost:443/ is vulnerable to CVE-2023-50969, Imperva SecureSphere "
         "WAF Bypass for POST Data Inspection Rules"
     )
 

--- a/tests/exploits/cve_2024_0692_test.py
+++ b/tests/exploits/cve_2024_0692_test.py
@@ -37,7 +37,7 @@ def testCVE20240692_whenVulnerable_reportFinding(
         == "SolarWinds Security Event Manager unauthenticated remote code execution"
     )
     assert vulnerability.technical_detail == (
-        "https://localhost:443 is vulnerable to CVE-2024-0692, SolarWinds Security "
+        "https://localhost:443/ is vulnerable to CVE-2024-0692, SolarWinds Security "
         "Event Manager unauthenticated remote code execution"
     )
 

--- a/tests/exploits/cve_2024_10542_test.py
+++ b/tests/exploits/cve_2024_10542_test.py
@@ -39,7 +39,7 @@ def testCVE202410542_whenVulnerable_reportFinding(
         == "CleanTalk Plugin Arbitrary Plugin Installation (Via Reverse DNS Spoofing)"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-10542, CleanTalk Plugin Arbitrary Plugin Installation (Via Reverse DNS Spoofing)"
+        "http://localhost:80/ is vulnerable to CVE-2024-10542, CleanTalk Plugin Arbitrary Plugin Installation (Via Reverse DNS Spoofing)"
     )
     assert vulnerability.risk_rating == vuln_mixin.RiskRating.HIGH
 

--- a/tests/exploits/cve_2024_10781_test.py
+++ b/tests/exploits/cve_2024_10781_test.py
@@ -39,7 +39,7 @@ def testCVE202410781_whenVulnerable_reportFinding(
         == "CleanTalk Unauthorized Arbitrary Plugin Installation"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-10781, CleanTalk Unauthorized Arbitrary Plugin Installation"
+        "http://localhost:80/ is vulnerable to CVE-2024-10781, CleanTalk Unauthorized Arbitrary Plugin Installation"
     )
     assert vulnerability.risk_rating == vuln_mixin.RiskRating.HIGH
 

--- a/tests/exploits/cve_2024_10905_test.py
+++ b/tests/exploits/cve_2024_10905_test.py
@@ -28,7 +28,7 @@ def testCVE202410905_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "SailPoint IdentityIQ Static File Exposure"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-10905, "
+        "http://localhost:80/ is vulnerable to CVE-2024-10905, "
         "SailPoint IdentityIQ Static File Exposure"
     )
 
@@ -77,6 +77,6 @@ def testCVE202410905_whenBelow82_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "SailPoint IdentityIQ Static File Exposure"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-10905, "
+        "http://localhost:80/ is vulnerable to CVE-2024-10905, "
         "SailPoint IdentityIQ Static File Exposure"
     )

--- a/tests/exploits/cve_2024_11205_test.py
+++ b/tests/exploits/cve_2024_11205_test.py
@@ -38,7 +38,7 @@ def testCVE202411205_whenVulnerable_reportFinding(
         == "WPForms Lite Plugin 1.8.4 - 1.9.2.1 - Missing Authorization to Authenticated (Subscriber+) Payment Refund and Subscription Cancellation"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-11205, WPForms Lite Plugin 1.8.4 - 1.9.2.1 - Missing Authorization to Authenticated (Subscriber+) Payment Refund and Subscription Cancellation"
+        "http://localhost:80/ is vulnerable to CVE-2024-11205, WPForms Lite Plugin 1.8.4 - 1.9.2.1 - Missing Authorization to Authenticated (Subscriber+) Payment Refund and Subscription Cancellation"
     )
     assert vulnerability.risk_rating == vuln_mixin.RiskRating.HIGH
 

--- a/tests/exploits/cve_2024_11639_test.py
+++ b/tests/exploits/cve_2024_11639_test.py
@@ -35,7 +35,7 @@ def testCVE202411639_whenVulnerable_reportFinding(
         vulnerability.entry.title == "Authentication Bypass in Ivanti CSA Admin Console"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-11639, "
+        "http://localhost:80/ is vulnerable to CVE-2024-11639, "
         "Authentication Bypass in Ivanti CSA Admin Console"
     )
 

--- a/tests/exploits/cve_2024_11667_test.py
+++ b/tests/exploits/cve_2024_11667_test.py
@@ -50,7 +50,7 @@ def testCVE202411667_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "http://localhost:80 is vulnerable to CVE-2024-11667, Zyxel ATP/USG FLEX/USG FLEX 50(W)/USG20(W)-VPN UP TO 5.38 URL PATH TRAVERSAL"
+        == "http://localhost:80/ is vulnerable to CVE-2024-11667, Zyxel ATP/USG FLEX/USG FLEX 50(W)/USG20(W)-VPN UP TO 5.38 URL PATH TRAVERSAL"
     )
 
 

--- a/tests/exploits/cve_2024_11972_test.py
+++ b/tests/exploits/cve_2024_11972_test.py
@@ -39,7 +39,7 @@ def testCVE202411972_whenVulnerable_reportFinding(
         == "Hunk Companion Plugin Unauthenticated Arbitrary Plugin Installation"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-11972, "
+        "http://localhost:80/ is vulnerable to CVE-2024-11972, "
         "Hunk Companion Plugin Unauthenticated Arbitrary Plugin Installation"
     )
     assert vulnerability.risk_rating == vuln_mixin.RiskRating.CRITICAL

--- a/tests/exploits/cve_2024_20419_test.py
+++ b/tests/exploits/cve_2024_20419_test.py
@@ -44,7 +44,7 @@ def testCVE202420419_whenVulnerable_reportsFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "https://example.com:443 is vulnerable to CVE-2024-20419: Account Takeover in Cisco Smart Software Manager On-Prem"
+        == "https://example.com:443/ is vulnerable to CVE-2024-20419: Account Takeover in Cisco Smart Software Manager On-Prem"
     )
 
 

--- a/tests/exploits/cve_2024_21287_test.py
+++ b/tests/exploits/cve_2024_21287_test.py
@@ -36,7 +36,7 @@ def testCVE202421287_whenVulnerable_reportFinding(
         vulnerability.entry.title == "Oracle Agile PLM Framework Remote File Disclosure"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-21287, "
+        "http://localhost:80/ is vulnerable to CVE-2024-21287, "
         "Oracle Agile PLM Framework Remote File Disclosure"
     )
 

--- a/tests/exploits/cve_2024_21733_test.py
+++ b/tests/exploits/cve_2024_21733_test.py
@@ -30,7 +30,7 @@ def testCVE202421733_whenVulnerable_reportFinding(
         == "Apache Tomcat HTTP Request Smuggling (Client- Side Desync)"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:8085 is vulnerable to CVE-2024-21733, Apache Tomcat HTTP "
+        "http://localhost:8085/ is vulnerable to CVE-2024-21733, Apache Tomcat HTTP "
         "Request Smuggling (Client- Side Desync)"
     )
 

--- a/tests/exploits/cve_2024_21762_test.py
+++ b/tests/exploits/cve_2024_21762_test.py
@@ -39,7 +39,7 @@ def testCVE202421762_whenVulnerable_reportFinding(
         == "Fortinet FortiOS Out-of-Bound Write SSL VPN Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:10443 is vulnerable to CVE-2024-21762, Fortinet "
+        "http://localhost:10443/ is vulnerable to CVE-2024-21762, Fortinet "
         "FortiOS Out-of-Bound Write SSL VPN Vulnerability"
     )
 

--- a/tests/exploits/cve_2024_2194_test.py
+++ b/tests/exploits/cve_2024_2194_test.py
@@ -32,7 +32,7 @@ def testCVE20242194_whenVulnerable_reportFinding(
         == "WP Statistics Unauthenticated Stored Cross-Site Scripting"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-2194, "
+        "http://localhost:80/ is vulnerable to CVE-2024-2194, "
         "WP Statistics Unauthenticated Stored Cross-Site Scripting"
     )
 

--- a/tests/exploits/cve_2024_23113_test.py
+++ b/tests/exploits/cve_2024_23113_test.py
@@ -39,7 +39,7 @@ def testCVE202423113_whenVulnerable_reportFinding(
     assert vulnerability.entry.risk_rating == "HIGH"
     assert vulnerability.risk_rating == agent_report_vulnerability_mixin.RiskRating.HIGH
     assert (
-        f"FortiOS device at udp://192.168.1.1:161 is running a vulnerable version: {vulnerable_version}"
+        f"FortiOS device at udp://192.168.1.1:161/ is running a vulnerable version: {vulnerable_version}"
         in vulnerability.technical_detail
     )
 
@@ -152,7 +152,7 @@ def testCVE202423113_whenSNMPFails_fallbackToOtherMethods(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == cve_2024_23113.VULNERABILITY_TITLE
     assert (
-        "FortiOS device at tcp://192.168.1.1:443 is running a vulnerable version: 7.0.5"
+        "FortiOS device at tcp://192.168.1.1:443/ is running a vulnerable version: 7.0.5"
         in vulnerability.technical_detail
     )
 
@@ -186,7 +186,7 @@ def testCVE202423113_withHTTPDetection_returnVulnerabilities(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == cve_2024_23113.VULNERABILITY_TITLE
     assert (
-        f"{expected_product} device at tcp://192.168.1.1:443 is running a vulnerable version: {'.'.join(map(str, expected_version))}"
+        f"{expected_product} device at tcp://192.168.1.1:443/ is running a vulnerable version: {'.'.join(map(str, expected_version))}"
         in vulnerability.technical_detail
     )
 
@@ -214,7 +214,7 @@ def testCVE202423113_withTCPDetection_returnVulnerabilities(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == cve_2024_23113.VULNERABILITY_TITLE
     assert (
-        "FortiOS device at tcp://192.168.1.1:53 is running a vulnerable version: 7.0.0"
+        "FortiOS device at tcp://192.168.1.1:53/ is running a vulnerable version: 7.0.0"
         in vulnerability.technical_detail
     )
 

--- a/tests/exploits/cve_2024_23334_test.py
+++ b/tests/exploits/cve_2024_23334_test.py
@@ -35,7 +35,7 @@ def testCVE202423334_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == "AIOHTTP Path Traversal"
     assert (
         vulnerability.technical_detail
-        == "http://localhost:8000 is vulnerable to CVE-2024-23334, AIOHTTP Path Traversal"
+        == "http://localhost:8000/ is vulnerable to CVE-2024-23334, AIOHTTP Path Traversal"
     )
 
 

--- a/tests/exploits/cve_2024_27198_test.py
+++ b/tests/exploits/cve_2024_27198_test.py
@@ -33,7 +33,7 @@ def testCVE202427198_whenVulnerable_reportFinding(
         "perform admin actions"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-27198, JetBrains TeamCity "
+        "http://localhost:80/ is vulnerable to CVE-2024-27198, JetBrains TeamCity "
         "before 2023.11.4 authentication bypass allowing to perform admin actions"
     )
 

--- a/tests/exploits/cve_2024_27497_test.py
+++ b/tests/exploits/cve_2024_27497_test.py
@@ -26,7 +26,7 @@ def testCVE202427497_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "Linksys E2000 1.0.06 authentication bypass"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-27497, Linksys E2000 1.0.06 "
+        "http://localhost:80/ is vulnerable to CVE-2024-27497, Linksys E2000 1.0.06 "
         "authentication bypass"
     )
 

--- a/tests/exploits/cve_2024_2879_test.py
+++ b/tests/exploits/cve_2024_2879_test.py
@@ -30,7 +30,7 @@ def testCVE20242879_whenVulnerable_reportFinding(
         == "LayerSlider 7.9.11 - 7.10.0 - Unauthenticated SQL Injection"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-2879, LayerSlider "
+        "http://localhost:80/ is vulnerable to CVE-2024-2879, LayerSlider "
         "7.9.11 - 7.10.0 - Unauthenticated SQL Injection"
     )
 

--- a/tests/exploits/cve_2024_28890_test.py
+++ b/tests/exploits/cve_2024_28890_test.py
@@ -27,7 +27,7 @@ def testCVE202428890_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "Forminator plugin flaw in WordPress sites"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-28890, Forminator plugin flaw "
+        "http://localhost:80/ is vulnerable to CVE-2024-28890, Forminator plugin flaw "
         "in WordPress sites"
     )
 

--- a/tests/exploits/cve_2024_28986_test.py
+++ b/tests/exploits/cve_2024_28986_test.py
@@ -51,7 +51,7 @@ def testCVE202428986_whenVulnerable_reportFinding(
         == "SolarWinds Web Help Desk 12.8.3 - Java Deserialization RCE"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-28986, SolarWinds Web Help Desk 12.8.3 - Java Deserialization RCE"
+        "http://localhost:80/ is vulnerable to CVE-2024-28986, SolarWinds Web Help Desk 12.8.3 - Java Deserialization RCE"
     )
 
 

--- a/tests/exploits/cve_2024_29269_test.py
+++ b/tests/exploits/cve_2024_29269_test.py
@@ -56,7 +56,7 @@ def testCVE202429269_whenVulnerable_reportFinding(
         == "Telesquare TLR-2005KSH Unauthorized Remote Command Execution Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-29269, Telesquare "
+        "http://localhost:80/ is vulnerable to CVE-2024-29269, Telesquare "
         "TLR-2005KSH Unauthorized Remote Command Execution Vulnerability"
     )
 

--- a/tests/exploits/cve_2024_3273_test.py
+++ b/tests/exploits/cve_2024_3273_test.py
@@ -36,7 +36,7 @@ def testCVE20243273_whenVulnerable_reportFinding(
         == "D-Link Multiple NAS Devices Command Injection Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-3273, D-Link Multiple NAS "
+        "http://localhost:80/ is vulnerable to CVE-2024-3273, D-Link Multiple NAS "
         "Devices Command Injection Vulnerability"
     )
 

--- a/tests/exploits/cve_2024_33544_test.py
+++ b/tests/exploits/cve_2024_33544_test.py
@@ -29,7 +29,7 @@ def testCVE202433544_whenVersionBetween1and13XX_reportFinding(
         == "Unauthenticated SQL Injection Vulnerability in WZone Plugin"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-33544, "
+        "http://localhost:80/ is vulnerable to CVE-2024-33544, "
         "Unauthenticated SQL Injection Vulnerability in WZone Plugin"
     )
 
@@ -57,7 +57,7 @@ def testCVE202433544_whenVersionBetween1400and14010_reportFinding(
         == "Unauthenticated SQL Injection Vulnerability in WZone Plugin"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-33544, "
+        "http://localhost:80/ is vulnerable to CVE-2024-33544, "
         "Unauthenticated SQL Injection Vulnerability in WZone Plugin"
     )
 

--- a/tests/exploits/cve_2024_34470_test.py
+++ b/tests/exploits/cve_2024_34470_test.py
@@ -36,7 +36,7 @@ def testCVE202434470_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "HSC MAILINSPECTOR PATH TRAVERSAL"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-34470, "
+        "http://localhost:80/ is vulnerable to CVE-2024-34470, "
         "HSC MAILINSPECTOR PATH TRAVERSAL"
     )
 

--- a/tests/exploits/cve_2024_37383_test.py
+++ b/tests/exploits/cve_2024_37383_test.py
@@ -29,7 +29,7 @@ def testCVE202437383_whenVersion156_reportFinding(
         == "XSS via SVG Animate Attributes in Roundcube Webmail"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-37383, "
+        "http://localhost:80/ is vulnerable to CVE-2024-37383, "
         "XSS via SVG Animate Attributes in Roundcube Webmail"
     )
 
@@ -57,7 +57,7 @@ def testCVE202437383_whenVersion166_reportFinding(
         == "XSS via SVG Animate Attributes in Roundcube Webmail"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-37383, "
+        "http://localhost:80/ is vulnerable to CVE-2024-37383, "
         "XSS via SVG Animate Attributes in Roundcube Webmail"
     )
 

--- a/tests/exploits/cve_2024_39717_test.py
+++ b/tests/exploits/cve_2024_39717_test.py
@@ -28,7 +28,7 @@ def testCVE202439717_whenVulnerable_reportFinding(
         == "Versa Director Dangerous File Type Upload Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-39717, Versa Director "
+        "http://localhost:80/ is vulnerable to CVE-2024-39717, Versa Director "
         "Dangerous File Type Upload Vulnerability"
     )
 

--- a/tests/exploits/cve_2024_4040_test.py
+++ b/tests/exploits/cve_2024_4040_test.py
@@ -36,7 +36,7 @@ def testCVE20244040_whenVulnerable_reportFinding(
         == "Unauthenticated arbitrary file read and remote code execution in CrushFTP"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-4040, Unauthenticated "
+        "http://localhost:80/ is vulnerable to CVE-2024-4040, Unauthenticated "
         "arbitrary file read and remote code execution in CrushFTP"
     )
 

--- a/tests/exploits/cve_2024_40711_test.py
+++ b/tests/exploits/cve_2024_40711_test.py
@@ -30,7 +30,7 @@ def testCVE202440711_whenVulnerable_reportFinding(
         == "Veeam Backup & Replication Remote Code Execution Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-40711, Veeam Backup & Replication Remote Code Execution "
+        "http://localhost:80/ is vulnerable to CVE-2024-40711, Veeam Backup & Replication Remote Code Execution "
         "Vulnerability"
     )
 

--- a/tests/exploits/cve_2024_40766_test.py
+++ b/tests/exploits/cve_2024_40766_test.py
@@ -37,7 +37,7 @@ def testCVE202440766_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == cve_2024_40766.VULNERABILITY_TITLE
     assert vulnerability.entry.risk_rating == "CRITICAL"
     assert vulnerability.technical_detail == (
-        f"SonicWall device at udp://192.168.1.1:161 is running a vulnerable version: {vulnerable_version}. "
+        f"SonicWall device at udp://192.168.1.1:161/ is running a vulnerable version: {vulnerable_version}. "
         "Immediate action is required."
     )
 

--- a/tests/exploits/cve_2024_42450_test.py
+++ b/tests/exploits/cve_2024_42450_test.py
@@ -36,7 +36,7 @@ def testCVE202442450_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == cve_2024_42450.VULNERABILITY_TITLE
     assert vulnerability.entry.risk_rating == "CRITICAL"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-42450, Versa Director Database exposure"
+        "http://localhost:80/ is vulnerable to CVE-2024-42450, Versa Director Database exposure"
     )
     mock_check_db_connection.assert_called_once_with(
         "localhost", "vnms", "vnms", "Versa@123"

--- a/tests/exploits/cve_2024_42509_test.py
+++ b/tests/exploits/cve_2024_42509_test.py
@@ -34,7 +34,7 @@ def testCVE202442509_whenVulnerable_reportFinding(mocker: plugin.MockerFixture) 
     assert vulnerability.entry.title == cve_2024_42509.VULNERABILITY_TITLE
     assert vulnerability.entry.risk_rating == "CRITICAL"
     assert vulnerability.technical_detail == (
-        f"HPE Aruba Networking Access Points device at udp://192.168.1.2:161 is running a vulnerable version: {vulnerable_version}. "
+        f"HPE Aruba Networking Access Points device at udp://192.168.1.2:161/ is running a vulnerable version: {vulnerable_version}. "
         "Immediate action is required."
     )
 

--- a/tests/exploits/cve_2024_43044_test.py
+++ b/tests/exploits/cve_2024_43044_test.py
@@ -31,7 +31,7 @@ def testCVE202443044_whenVulnerableLTS_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "JENKINS ARBITRARY FILE READ TO RCE"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-43044, "
+        "http://localhost:80/ is vulnerable to CVE-2024-43044, "
         "JENKINS ARBITRARY FILE READ TO RCE"
     )
 
@@ -61,7 +61,7 @@ def testCVE202443044_whenVulnerableNonLTS_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "JENKINS ARBITRARY FILE READ TO RCE"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-43044, "
+        "http://localhost:80/ is vulnerable to CVE-2024-43044, "
         "JENKINS ARBITRARY FILE READ TO RCE"
     )
 

--- a/tests/exploits/cve_2024_43399_test.py
+++ b/tests/exploits/cve_2024_43399_test.py
@@ -31,7 +31,7 @@ def testCVE202443399_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "Mobile Security Framework (MobSF) Zip Slip"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-43399, "
+        "http://localhost:80/ is vulnerable to CVE-2024-43399, "
         "Mobile Security Framework (MobSF) Zip Slip"
     )
 

--- a/tests/exploits/cve_2024_4439_test.py
+++ b/tests/exploits/cve_2024_4439_test.py
@@ -28,7 +28,7 @@ def testCVE20244439_whenVulnerable_reportFinding(
         == "Unauthenticated Stored Cross-Site Scripting Vulnerability in WordPress Core"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-4439, Unauthenticated Stored "
+        "http://localhost:80/ is vulnerable to CVE-2024-4439, Unauthenticated Stored "
         "Cross-Site Scripting Vulnerability in WordPress Core"
     )
 

--- a/tests/exploits/cve_2024_45409_test.py
+++ b/tests/exploits/cve_2024_45409_test.py
@@ -34,7 +34,7 @@ def testCVE202445409_whenVulnerable_reportFinding(
     )
     assert (
         vulnerability.technical_detail
-        == "https://localhost:8080 is vulnerable to CVE-2024-45409, GitLab SAML Authentication Bypass Vulnerability."
+        == "https://localhost:8080/ is vulnerable to CVE-2024-45409, GitLab SAML Authentication Bypass Vulnerability."
     )
     assert vulnerability.risk_rating.name == "POTENTIALLY"
 

--- a/tests/exploits/cve_2024_47374_test.py
+++ b/tests/exploits/cve_2024_47374_test.py
@@ -33,7 +33,7 @@ def testCVE202447374_whenVulnerable_reportFinding(
         == "Stored Cross-Site Scripting (XSS) Vulnerability in LiteSpeed Cache for WordPress"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-47374, Stored Cross-Site "
+        "http://localhost:80/ is vulnerable to CVE-2024-47374, Stored Cross-Site "
         "Scripting (XSS) Vulnerability in LiteSpeed Cache for WordPress"
     )
 

--- a/tests/exploits/cve_2024_47533_test.py
+++ b/tests/exploits/cve_2024_47533_test.py
@@ -61,7 +61,7 @@ def testCVE202447533_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "Cobbler XMLRPC Interface Authentication Bypass"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-47533, Cobbler XMLRPC Interface Authentication Bypass"
+        "http://localhost:80/ is vulnerable to CVE-2024-47533, Cobbler XMLRPC Interface Authentication Bypass"
     )
 
 

--- a/tests/exploits/cve_2024_47575_test.py
+++ b/tests/exploits/cve_2024_47575_test.py
@@ -39,7 +39,7 @@ def testCVE202447575_whenVulnerable_reportFinding(
         == "Missing Authentication for critical function in FortiManager"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-47575, "
+        "http://localhost:80/ is vulnerable to CVE-2024-47575, "
         "Missing Authentication for critical function in FortiManager"
     )
 

--- a/tests/exploits/cve_2024_50550_test.py
+++ b/tests/exploits/cve_2024_50550_test.py
@@ -34,7 +34,7 @@ def testCVE202450550_whenVulnerable_reportFinding(
         == "LiteSpeed Cache Vulnerability Allowing privilege escalation"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-50550, LiteSpeed "
+        "http://localhost:80/ is vulnerable to CVE-2024-50550, LiteSpeed "
         "Cache Vulnerability Allowing privilege escalation"
     )
 

--- a/tests/exploits/cve_2024_50623_test.py
+++ b/tests/exploits/cve_2024_50623_test.py
@@ -30,7 +30,7 @@ def testCVE202450623_whenVulnerable_reportFinding(
         == "Cleo Harmony, VLTrader, and LexiCom - Unrestricted File Upload and Download Leading to Remote Code Execution"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-50623, Cleo Harmony, VLTrader, and LexiCom -"
+        "http://localhost:80/ is vulnerable to CVE-2024-50623, Cleo Harmony, VLTrader, and LexiCom -"
         " Unrestricted File Upload and Download Leading to Remote Code Execution"
     )
     assert vulnerability.risk_rating == vuln_mixin.RiskRating.CRITICAL

--- a/tests/exploits/cve_2024_51378_test.py
+++ b/tests/exploits/cve_2024_51378_test.py
@@ -36,7 +36,7 @@ def testCVE202451378_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == "CYBERPANEL RCE"
     assert vulnerability.risk_rating.name == "CRITICAL"
     assert vulnerability.technical_detail == (
-        "http://127.0.0.1:8090 is vulnerable to CVE-2024-51378, CYBERPANEL RCE"
+        "http://127.0.0.1:8090/ is vulnerable to CVE-2024-51378, CYBERPANEL RCE"
     )
 
 

--- a/tests/exploits/cve_2024_51479_test.py
+++ b/tests/exploits/cve_2024_51479_test.py
@@ -34,7 +34,7 @@ def testCVE202451479_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == "Next.js Authorization Bypass via Middleware"
     assert (
         vulnerability.technical_detail
-        == "http://localhost:80 is vulnerable to CVE-2024-51479, Next.js Authorization Bypass via Middleware"
+        == "http://localhost:80/ is vulnerable to CVE-2024-51479, Next.js Authorization Bypass via Middleware"
     )
 
 

--- a/tests/exploits/cve_2024_5315_test.py
+++ b/tests/exploits/cve_2024_5315_test.py
@@ -26,7 +26,7 @@ def testCVE20245315_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "Dolibarr ERP-CRM 9.0.1 - SQL Injection"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-5315, Dolibarr ERP-CRM 9.0.1 - SQL Injection"
+        "http://localhost:80/ is vulnerable to CVE-2024-5315, Dolibarr ERP-CRM 9.0.1 - SQL Injection"
     )
 
 

--- a/tests/exploits/cve_2024_54134_test.py
+++ b/tests/exploits/cve_2024_54134_test.py
@@ -29,7 +29,7 @@ def testCVE202454134_whenVulnerable_reportFinding(
         == "MALICIOUS PACKAGES FOUND IN COMPROMISED @SOLANA/WEB3.JS LIBRARY"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-54134, MALICIOUS PACKAGES FOUND IN COMPROMISED @SOLANA/WEB3.JS LIBRARY"
+        "http://localhost:80/ is vulnerable to CVE-2024-54134, MALICIOUS PACKAGES FOUND IN COMPROMISED @SOLANA/WEB3.JS LIBRARY"
     )
 
 

--- a/tests/exploits/cve_2024_55956_test.py
+++ b/tests/exploits/cve_2024_55956_test.py
@@ -30,7 +30,7 @@ def testCVE202455956_whenVulnerable_reportFinding(
         == "Cleo Harmony, VLTrader, and LexiCom - Arbitrary Command Execution via Autorun Directory"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-55956, Cleo Harmony, VLTrader, and LexiCom -"
+        "http://localhost:80/ is vulnerable to CVE-2024-55956, Cleo Harmony, VLTrader, and LexiCom -"
         " Arbitrary Command Execution via Autorun Directory"
     )
     assert vulnerability.risk_rating == vuln_mixin.RiskRating.CRITICAL

--- a/tests/exploits/cve_2024_6385_test.py
+++ b/tests/exploits/cve_2024_6385_test.py
@@ -32,7 +32,7 @@ def testCVE20246385_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == "GitLab Authentication Bypass Vulnerability."
     assert (
         vulnerability.technical_detail
-        == "https://localhost:8080 is vulnerable to CVE-2024-6385, GitLab Authentication Bypass Vulnerability."
+        == "https://localhost:8080/ is vulnerable to CVE-2024-6385, GitLab Authentication Bypass Vulnerability."
     )
     assert vulnerability.risk_rating.name == "POTENTIALLY"
 

--- a/tests/exploits/cve_2024_6386_test.py
+++ b/tests/exploits/cve_2024_6386_test.py
@@ -27,7 +27,7 @@ def testCVE20246386_whenVersionUpTo4612_reportFinding(
         == "WPML Multilingual CMS Authenticated Contributor+ Remote Code Execution (RCE) via Twig Server-Side Template Injection (SSTI)"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-6386, "
+        "http://localhost:80/ is vulnerable to CVE-2024-6386, "
         "WPML Multilingual CMS Authenticated Contributor+ Remote Code Execution (RCE) via Twig Server-Side Template Injection (SSTI)"
     )
 
@@ -55,7 +55,7 @@ def testCVE20246386_whenVersionBetween401And4612_reportFinding(
         == "WPML Multilingual CMS Authenticated Contributor+ Remote Code Execution (RCE) via Twig Server-Side Template Injection (SSTI)"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-6386, "
+        "http://localhost:80/ is vulnerable to CVE-2024-6386, "
         "WPML Multilingual CMS Authenticated Contributor+ Remote Code Execution (RCE) via Twig Server-Side Template Injection (SSTI)"
     )
 

--- a/tests/exploits/cve_2024_7029_test.py
+++ b/tests/exploits/cve_2024_7029_test.py
@@ -35,7 +35,7 @@ def testCVE20247029_whenVulnerable_reportFinding(
         == "AVTECH IP camera Devices Command Injection Vulnerability"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-7029, AVTECH IP camera Devices Command Injection Vulnerability"
+        "http://localhost:80/ is vulnerable to CVE-2024-7029, AVTECH IP camera Devices Command Injection Vulnerability"
     )
 
 

--- a/tests/exploits/cve_2024_7120_test.py
+++ b/tests/exploits/cve_2024_7120_test.py
@@ -41,7 +41,7 @@ def testCVE20247120_whenVulnerable_reportsFinding(
     assert vulnerability.entry.title == "Command Injection in RAISECOM Gateway Devices"
     assert (
         vulnerability.technical_detail
-        == "http://example.com:80 is vulnerable to CVE-2024-7120: Command Injection in RAISECOM Gateway Devices"
+        == "http://example.com:80/ is vulnerable to CVE-2024-7120: Command Injection in RAISECOM Gateway Devices"
     )
 
 

--- a/tests/exploits/cve_2024_8522_test.py
+++ b/tests/exploits/cve_2024_8522_test.py
@@ -168,5 +168,5 @@ def testCve20248522_whenVulnerable_technicalDetailContainsOriginInsteadOfUrl(
         )
         assert (
             vulnerabilities[0].technical_detail
-            == "http://example.com:80 is vulnerable to CVE-2024-8522, Unauthenticated SQL Injection Vulnerability in LearnPress Plugin"
+            == "http://example.com:80/ is vulnerable to CVE-2024-8522, Unauthenticated SQL Injection Vulnerability in LearnPress Plugin"
         )

--- a/tests/exploits/cve_2024_8672_test.py
+++ b/tests/exploits/cve_2024_8672_test.py
@@ -38,7 +38,7 @@ def testCVE20248672_whenVulnerable_reportFinding(
         == "Widget Options Plugin <= 4.0.7 - Authenticated Remote Code Execution"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-8672, Widget Options Plugin <= 4.0.7 - Authenticated Remote Code Execution"
+        "http://localhost:80/ is vulnerable to CVE-2024-8672, Widget Options Plugin <= 4.0.7 - Authenticated Remote Code Execution"
     )
     assert vulnerability.risk_rating == vuln_mixin.RiskRating.CRITICAL
 

--- a/tests/exploits/cve_2024_9164_test.py
+++ b/tests/exploits/cve_2024_9164_test.py
@@ -31,7 +31,7 @@ def testCVE20249164_whenVulnerable_reportFinding(
     assert vulnerability.entry.title == "Gitlab Run pipelines on arbitrary branches."
     assert (
         vulnerability.technical_detail
-        == "https://localhost:8080 is vulnerable to CVE-2024-9164, Gitlab Run pipelines on arbitrary branches."
+        == "https://localhost:8080/ is vulnerable to CVE-2024-9164, Gitlab Run pipelines on arbitrary branches."
     )
     assert vulnerability.risk_rating.name == "CRITICAL"
 
@@ -61,7 +61,7 @@ def testCVE20249164_whenPotentiallyVulnerable_reportFinding(
     assert vulnerability.entry.title == "Gitlab Run pipelines on arbitrary branches."
     assert (
         vulnerability.technical_detail
-        == "https://localhost:8080 is vulnerable to CVE-2024-9164, Gitlab Run pipelines on arbitrary branches."
+        == "https://localhost:8080/ is vulnerable to CVE-2024-9164, Gitlab Run pipelines on arbitrary branches."
     )
     assert vulnerability.risk_rating.name == "POTENTIALLY"
 

--- a/tests/exploits/cve_2024_9487_test.py
+++ b/tests/exploits/cve_2024_9487_test.py
@@ -29,7 +29,7 @@ def testCVE20249487_whenVulnerable_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "GITHUB ENTERPRISE SERVER AUTHENTICATION BYPASS"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-9487, "
+        "http://localhost:80/ is vulnerable to CVE-2024-9487, "
         "GITHUB ENTERPRISE SERVER AUTHENTICATION BYPASS"
     )
 
@@ -80,6 +80,6 @@ def testCVE20249487_whenVersionVeryOld_reportFinding(
     vulnerability = vulnerabilities[0]
     assert vulnerability.entry.title == "GITHUB ENTERPRISE SERVER AUTHENTICATION BYPASS"
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to CVE-2024-9487, "
+        "http://localhost:80/ is vulnerable to CVE-2024-9487, "
         "GITHUB ENTERPRISE SERVER AUTHENTICATION BYPASS"
     )

--- a/tests/exploits/exposed_adb_test.py
+++ b/tests/exploits/exposed_adb_test.py
@@ -30,7 +30,7 @@ def testExposedAdb_whenVulnerable_reportFinding(
         == "Unauthenticated exposed Android Debug Bridge (ADB)"
     )
     assert vulnerability.technical_detail == (
-        "127.0.0.1:5555 is vulnerable to Unauthenticated exposed Android Debug "
+        "tcp://127.0.0.1:5555/ is vulnerable to Unauthenticated exposed Android Debug "
         "Bridge (ADB)."
     )
 

--- a/tests/exploits/jetpack_version_detection_test.py
+++ b/tests/exploits/jetpack_version_detection_test.py
@@ -34,7 +34,7 @@ def testCVE20249487_whenVulnerable_reportFinding(
         == "UNAUTHORIZED FORM DATA EXPOSURE VULNERABILITY IN JETPACK'S CONTACT FORM FEATURE"
     )
     assert vulnerability.technical_detail == (
-        "http://localhost:80 is vulnerable to jetpack data exposure, "
+        "http://localhost:80/ is vulnerable to jetpack data exposure, "
         "UNAUTHORIZED FORM DATA EXPOSURE VULNERABILITY IN JETPACK'S CONTACT FORM FEATURE"
     )
 


### PR DESCRIPTION
Fix technical detail should contain url not origin + other refactoring

Since for example a vulnerability in https://www.google.com/ads is not necessarly a vuln in https://www.google.com/cloud.

This is important because the dna is computed based on the technical details, alogside the title and the vuln location.