### PR TITLE
Fix Asteroid Agent __init__ issue

### DIFF
--- a/agent/asteroid_agent.py
+++ b/agent/asteroid_agent.py
@@ -57,6 +57,7 @@ class AsteroidAgent(
         """Initialize The Agent instance."""
 
         super().__init__(agent_definition, agent_settings)
+        persist_mixin.AgentPersistMixin.__init__(self, agent_settings)
         exploits.import_all()
         self.exploits: list[definitions.Exploit] = (
             exploits_registry.ExploitsRegistry.values()


### PR DESCRIPTION
### Fix Asteroid Agent broken since last week

![image](https://github.com/user-attachments/assets/68aaaa19-0afb-425a-93a0-ec3f7dc81597)

Last week, a new logic was added to check whether a target has already been processed.  

To implement this, the agent now inherits from `persist_mixin.AgentPersistMixin`. However, since `AgentPersistMixin`'s `__init__` method initializes `self._redis_client` using:  

```python
self._redis_client = redis.Redis.from_url(agent_settings.redis_url)
```
Any agent that inherits from AgentPersistMixin must ensure its __init__ method properly calls the parent class’s __init__ method first to initialize dependencies correctly.

![image](https://github.com/user-attachments/assets/e8086ab6-baba-483e-a276-4ff709d9c04c)
