### PR TITLE
feature: Add Detection for CVE-2019-9874

### DIFF
--- a/agent/exploits/cve_2019_9874.py
+++ b/agent/exploits/cve_2019_9874.py
@@ -1,0 +1,90 @@
+"""Agent Asteroid implementation for CVE-2019-9874"""
+
+import datetime
+import logging
+import re
+
+from requests import exceptions as requests_exceptions
+
+from agent import definitions
+from agent import exploits_registry
+from agent.exploits import webexploit
+
+VULNERABILITY_TITLE = "Sitecore Anti-CSRF Unauthenticated Deserialization"
+VULNERABILITY_REFERENCE = "CVE-2019-9874"
+VULNERABILITY_DESCRIPTION = """
+Deserialization of untrusted data in Sitecore CMS and XP allows unauthenticated attackers
+to execute arbitrary code via a crafted __CSRFTOKEN POST parameter.
+"""
+RISK_RATING = "CRITICAL"
+DEFAULT_TIMEOUT = datetime.timedelta(seconds=10)
+
+SITECORE_PATTERN = r"<title>\s*Welcome to Sitecore\s*<\/title>"
+TEST_ENDPOINT = "/sitecore/shell/Applications/Security/CreateNewUser/CreateNewUser.aspx"
+
+# Minimal harmless payload to trigger deserialization error
+STATIC_PAYLOAD = "/wEAAAAAAAEAAAAAA"  # Small dummy ObjectStateFormatter Base64 payload
+
+
+@exploits_registry.register
+class SitecoreAntiCSRFDeserializationExploit(webexploit.WebExploit):
+    """
+    CVE-2019-9874: Sitecore Anti-CSRF Deserialization
+    """
+
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+    )
+
+    def accept(self, target: definitions.Target) -> bool:
+        """
+        Check if the target appears to be a Sitecore instance.
+        """
+        try:
+            response = self.session.get(
+                f"{target.origin}",
+                verify=False,
+                timeout=DEFAULT_TIMEOUT.seconds,
+            )
+            return re.search(SITECORE_PATTERN, response.text, re.IGNORECASE) is not None
+
+        except requests_exceptions.RequestException:
+            return False
+
+    def check(self, target: definitions.Target) -> list[definitions.Vulnerability]:
+        """
+        Send a serialized payload in __CSRFTOKEN and check if the server reacts abnormally.
+        """
+        vulnerabilities: list[definitions.Vulnerability] = []
+
+        try:
+            url = f"{target.origin}{TEST_ENDPOINT}"
+
+            cookies = {"__CSRFCOOKIE": "test"}
+
+            data = {"__CSRFTOKEN": STATIC_PAYLOAD}
+
+            response = self.session.post(
+                url,
+                cookies=cookies,
+                data=data,
+                verify=False,
+                timeout=DEFAULT_TIMEOUT.seconds,
+                allow_redirects=True,
+            )
+
+            # We expect 500 Internal Server Error or CSRF validation errors if vulnerable
+            if (
+                response.status_code == 500
+                and "PotentialCsrfException" in response.text
+            ):
+                vuln = self.create_vulnerability(target)
+                vulnerabilities.append(vuln)
+
+        except requests_exceptions.RequestException as e:
+            logging.error("Check: Error sending payload: %s", e)
+
+        return vulnerabilities

--- a/tests/exploits/cve_2019_9874_test.py
+++ b/tests/exploits/cve_2019_9874_test.py
@@ -17,9 +17,9 @@ def testCVE20199874_whenTargetIsSitecore_accepts(
         "https://127.0.0.1:4443",
         text="<title>Welcome to Sitecore</title>",
     )
-    
+
     accept = exploit_instance.accept(target)
-    
+
     assert accept is True
 
 

--- a/tests/exploits/cve_2019_9874_test.py
+++ b/tests/exploits/cve_2019_9874_test.py
@@ -13,13 +13,13 @@ def testCVE20199874_whenTargetIsSitecore_accepts(
     """Unit test for Sitecore Anti-CSRF exploit, case when target is Sitecore."""
     target = definitions.Target(scheme="https", host="127.0.0.1", port=4443)
     exploit_instance = cve_2019_9874.SitecoreAntiCSRFDeserializationExploit()
-
     requests_mock.get(
         "https://127.0.0.1:4443",
         text="<title>Welcome to Sitecore</title>",
     )
-
+    
     accept = exploit_instance.accept(target)
+    
     assert accept is True
 
 

--- a/tests/exploits/cve_2019_9874_test.py
+++ b/tests/exploits/cve_2019_9874_test.py
@@ -1,0 +1,105 @@
+"""Unit tests for CVE-2019-9874"""
+
+import requests_mock as req_mock
+from requests import exceptions as requests_exceptions
+
+from agent import definitions
+from agent.exploits import cve_2019_9874
+
+
+def testCVE20199874_whenTargetIsSitecore_accepts(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """Unit test for Sitecore Anti-CSRF exploit, case when target is Sitecore."""
+    target = definitions.Target(scheme="https", host="127.0.0.1", port=4443)
+    exploit_instance = cve_2019_9874.SitecoreAntiCSRFDeserializationExploit()
+
+    requests_mock.get(
+        "https://127.0.0.1:4443",
+        text="<title>Welcome to Sitecore</title>",
+    )
+
+    accept = exploit_instance.accept(target)
+    assert accept is True
+
+
+def testCVE20199874_whenTargetIsNotSitecore_rejects(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """Unit test for Sitecore Anti-CSRF exploit, case when target is not Sitecore."""
+    target = definitions.Target(scheme="https", host="127.0.0.1", port=4443)
+    exploit_instance = cve_2019_9874.SitecoreAntiCSRFDeserializationExploit()
+
+    requests_mock.get(
+        "https://127.0.0.1:4443",
+        text="<title>Generic CMS</title>",
+    )
+
+    accept = exploit_instance.accept(target)
+    assert accept is False
+
+
+def testCVE20199874_whenDeserializationErrorOccurs_reportsVulnerability(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """Unit test for Sitecore Anti-CSRF exploit, case when deserialization error indicates vulnerability."""
+    target = definitions.Target(scheme="https", host="127.0.0.1", port=4443)
+    exploit_instance = cve_2019_9874.SitecoreAntiCSRFDeserializationExploit()
+
+    requests_mock.post(
+        "https://127.0.0.1:4443/sitecore/shell/Applications/Security/CreateNewUser/CreateNewUser.aspx",
+        status_code=500,
+        text="PotentialCsrfException: The CSRF cookie value did not match the CSRF parameter value.",
+    )
+
+    vulnerabilities = exploit_instance.check(target)
+    assert len(vulnerabilities) > 0
+    assert vulnerabilities[0].entry.title == "Sitecore Anti-CSRF Unauthenticated Deserialization"
+    assert vulnerabilities[0].risk_rating.name == "CRITICAL"
+    assert vulnerabilities[0].vulnerability_location is not None
+    assert vulnerabilities[0].dna is not None
+
+
+def testCVE20199874_whenDeserializationErrorDoesNotOccur_reportsNothing(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """Unit test for Sitecore Anti-CSRF exploit, case when no deserialization error happens."""
+    target = definitions.Target(scheme="https", host="127.0.0.1", port=4443)
+    exploit_instance = cve_2019_9874.SitecoreAntiCSRFDeserializationExploit()
+
+    requests_mock.post(
+        "https://127.0.0.1:4443/sitecore/shell/Applications/Security/CreateNewUser/CreateNewUser.aspx",
+        status_code=200,
+        text="OK",
+    )
+
+    vulnerabilities = exploit_instance.check(target)
+    assert len(vulnerabilities) == 0
+
+
+def testCVE20199874_whenRequestExceptionOccurs_doesNotRaise(
+    requests_mock: req_mock.mocker.Mocker,
+) -> None:
+    """Unit test for Sitecore Anti-CSRF exploit, ensuring request exceptions are handled gracefully."""
+    target = definitions.Target(scheme="https", host="127.0.0.1", port=4443)
+    exploit_instance = cve_2019_9874.SitecoreAntiCSRFDeserializationExploit()
+
+    requests_mock.post(
+        "https://127.0.0.1:4443/sitecore/shell/Applications/Security/CreateNewUser/CreateNewUser.aspx",
+        exc=requests_exceptions.RequestException,
+    )
+
+    vulnerabilities = exploit_instance.check(target)
+    assert len(vulnerabilities) == 0
+
+
+def test() -> None:
+    """Unit test for Sitecore Anti-CSRF exploit, case when target is Sitecore."""
+    target = definitions.Target(scheme="https", host="12.43.214.129", port=443)
+    exploit_instance = cve_2019_9874.SitecoreAntiCSRFDeserializationExploit()
+
+    # accept = exploit_instance.accept(target)
+    # assert accept is True
+
+    vulnerabilities = exploit_instance.check(target)
+    assert len(vulnerabilities) > 0

--- a/tests/exploits/cve_2019_9874_test.py
+++ b/tests/exploits/cve_2019_9874_test.py
@@ -54,7 +54,10 @@ def testCVE20199874_whenDeserializationErrorOccurs_reportsVulnerability(
 
     vulnerabilities = exploit_instance.check(target)
     assert len(vulnerabilities) > 0
-    assert vulnerabilities[0].entry.title == "Sitecore Anti-CSRF Unauthenticated Deserialization"
+    assert (
+        vulnerabilities[0].entry.title
+        == "Sitecore Anti-CSRF Unauthenticated Deserialization"
+    )
     assert vulnerabilities[0].risk_rating.name == "CRITICAL"
     assert vulnerabilities[0].vulnerability_location is not None
     assert vulnerabilities[0].dna is not None
@@ -91,15 +94,3 @@ def testCVE20199874_whenRequestExceptionOccurs_doesNotRaise(
 
     vulnerabilities = exploit_instance.check(target)
     assert len(vulnerabilities) == 0
-
-
-def test() -> None:
-    """Unit test for Sitecore Anti-CSRF exploit, case when target is Sitecore."""
-    target = definitions.Target(scheme="https", host="12.43.214.129", port=443)
-    exploit_instance = cve_2019_9874.SitecoreAntiCSRFDeserializationExploit()
-
-    # accept = exploit_instance.accept(target)
-    # assert accept is True
-
-    vulnerabilities = exploit_instance.check(target)
-    assert len(vulnerabilities) > 0


### PR DESCRIPTION
## Add Agent Asteroid Implementation for CVE-2019-9874

### Summary
This PR adds a new agent module for detecting **Sitecore Anti-CSRF Unauthenticated Deserialization** (CVE-2019-9874).

It checks if a Sitecore instance is vulnerable by sending a static, harmless serialized payload via the `__CSRFTOKEN` parameter and observing the server's response.

### Details
- **Detection method**:  
  - Match homepage title with `Welcome to Sitecore`.
  - Send a small Base64 payload (`/wEAAAAAAAEAAAAAA`) to `/sitecore/shell/Applications/Security/CreateNewUser/CreateNewUser.aspx`.
  - If the server responds with a **500 Internal Server Error** and mentions `PotentialCsrfException`, the target is flagged as vulnerable.

- **Important**:  
  - No real payload or remote code execution is attempted.
  - Based on public research describing the deserialization flaw where a malicious payload (e.g., generated with `ysoserial.net`) could lead to RCE.

### References
- CVE: [CVE-2019-9874](https://nvd.nist.gov/vuln/detail/CVE-2019-9874)
- [Public research and PoC](https://www.synacktiv.com/ressources/advisories/Sitecore_CSRF_deserialize_RCE.pdf)

## Notes
- All exceptions are handled gracefully.
- This module only performs safe detection without exploiting the vulnerability.
- It hasn't been tested yet against a vulnerable target since none were found so far.

