### PR TITLE
feature: add-CVE-2025-10035

### DIFF
--- a/agent/exploits/cve_2025_10035.py
+++ b/agent/exploits/cve_2025_10035.py
@@ -36,7 +36,6 @@ SUSTAIN_MAX = version.parse("7.6.3")
 GOANYWHERE_PATTERNS = [
     r"GoAnywhere\s+Managed\s+File\s+Transfer",
     r"GoAnywhere\s+MFT",
-    r"Fortra.*GoAnywhere",
 ]
 
 VERSION_PATTERN = re.compile(r"GoAnywhere\s+([0-9]+\.[0-9]+\.[0-9]+)")

--- a/agent/exploits/cve_2025_10035.py
+++ b/agent/exploits/cve_2025_10035.py
@@ -2,7 +2,6 @@
 
 import re
 import logging
-from typing import List, Optional
 
 from requests import exceptions as requests_exceptions
 from packaging import version
@@ -95,7 +94,7 @@ class GoAnywhereDeserializationExploit(definitions.Exploit):
         except requests_exceptions.RequestException:
             return False
 
-    def check(self, target: definitions.Target) -> List[definitions.Vulnerability]:
+    def check(self, target: definitions.Target) -> list[definitions.Vulnerability]:
         """
         Check if the GoAnywhere MFT instance is vulnerable to CVE-2025-10035.
 
@@ -105,7 +104,7 @@ class GoAnywhereDeserializationExploit(definitions.Exploit):
         Returns:
             List of vulnerabilities found (empty list if none)
         """
-        vulnerabilities: List[definitions.Vulnerability] = []
+        vulnerabilities: list[definitions.Vulnerability] = []
 
         try:
             # Get the login page to extract version information
@@ -168,7 +167,7 @@ class GoAnywhereDeserializationExploit(definitions.Exploit):
             logger.error(f"Regex error in GoAnywhere detection: {e}")
             return False
 
-    def _extract_version(self, response_text: str) -> Optional[str]:
+    def _extract_version(self, response_text: str) -> str | None:
         """
         Extract GoAnywhere version from response text.
 

--- a/agent/exploits/cve_2025_10035.py
+++ b/agent/exploits/cve_2025_10035.py
@@ -1,0 +1,219 @@
+"""Agent Asteroid implementation for CVE-2025-10035"""
+
+import re
+import logging
+from typing import List, Optional
+
+from requests import exceptions as requests_exceptions
+from packaging import version
+
+from agent import definitions
+from agent import exploits_registry
+
+VULNERABILITY_TITLE = "GoAnywhere MFT License Servlet Deserialization Vulnerability"
+VULNERABILITY_REFERENCE = "CVE-2025-10035"
+VULNERABILITY_DESCRIPTION = (
+    "A deserialization vulnerability in the License Servlet of Fortra's GoAnywhere MFT allows "
+    "remote attackers to execute arbitrary code via crafted serialized data. This vulnerability "
+    "affects multiple version ranges of GoAnywhere MFT and can be exploited without authentication."
+)
+VULNERABILITY_RECOMMENDATION = (
+    "- Update GoAnywhere MFT to version 7.8.5 or later\n"
+    "- If using sustained support versions, upgrade beyond 7.6.3\n"
+    "- Apply security patches from Fortra\n"
+    "- Monitor network traffic for exploitation attempts\n"
+    "- Implement network segmentation to limit access to GoAnywhere MFT instances"
+)
+RISK_RATING = "CRITICAL"
+DEFAULT_TIMEOUT = 30
+
+# Version ranges that are vulnerable
+LATEST_MIN = version.parse("7.7.0")
+LATEST_MAX = version.parse("7.8.4")
+SUSTAIN_MAX = version.parse("7.6.3")
+
+# GoAnywhere identification patterns
+GOANYWHERE_PATTERNS = [
+    r"GoAnywhere\s+Managed\s+File\s+Transfer",
+    r"GoAnywhere\s+MFT",
+    r"Fortra.*GoAnywhere",
+]
+
+VERSION_PATTERN = re.compile(r"GoAnywhere\s+([0-9]+\.[0-9]+\.[0-9]+)")
+LOGIN_ENDPOINT = "/goanywhere/auth/Login.xhtml"
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@exploits_registry.register
+class GoAnywhereDeserializationExploit(definitions.Exploit):
+    """
+    CVE-2025-10035: GoAnywhere MFT License Servlet Deserialization Vulnerability
+    """
+
+    metadata = definitions.VulnerabilityMetadata(
+        title=VULNERABILITY_TITLE,
+        description=VULNERABILITY_DESCRIPTION,
+        reference=VULNERABILITY_REFERENCE,
+        risk_rating=RISK_RATING,
+        recommendation=VULNERABILITY_RECOMMENDATION,
+        has_public_exploit=True,
+        targeted_by_malware=False,
+        targeted_by_ransomware=False,
+        targeted_by_nation_state=False,
+        cve_ids=[VULNERABILITY_REFERENCE],
+        references={
+            "github.com": "https://github.com/advisories/GHSA-fcfw-g3g2-2588",
+            "fortra.com": "https://www.fortra.com/security-advisories",
+        },
+    )
+
+    def accept(self, target: definitions.Target) -> bool:
+        """
+        Check if the target appears to be a GoAnywhere MFT instance.
+
+        Args:
+            target: The target to check
+
+        Returns:
+            True if target appears to be GoAnywhere MFT, False otherwise
+        """
+        try:
+            # Try the login endpoint first
+            login_url = f"{target.origin}{LOGIN_ENDPOINT}"
+            response = self.session.get(login_url, timeout=DEFAULT_TIMEOUT)
+
+            # Check if this looks like GoAnywhere
+            if self._is_goanywhere_response(response.text) is True:
+                return True
+
+            # Fallback: try root endpoint
+            root_response = self.session.get(target.origin, timeout=DEFAULT_TIMEOUT)
+
+            return self._is_goanywhere_response(root_response.text) is True
+
+        except requests_exceptions.RequestException:
+            return False
+
+    def check(self, target: definitions.Target) -> List[definitions.Vulnerability]:
+        """
+        Check if the GoAnywhere MFT instance is vulnerable to CVE-2025-10035.
+
+        Args:
+            target: The target to test for vulnerability
+
+        Returns:
+            List of vulnerabilities found (empty list if none)
+        """
+        vulnerabilities: List[definitions.Vulnerability] = []
+
+        try:
+            # Get the login page to extract version information
+            login_url = f"{target.origin}{LOGIN_ENDPOINT}"
+            response = self.session.get(login_url, timeout=DEFAULT_TIMEOUT)
+
+            # Confirm this is GoAnywhere
+            if self._is_goanywhere_response(response.text) is False:
+                return vulnerabilities
+
+            detected_version = self._extract_version(response.text)
+            if detected_version is None:
+                logger.warning(
+                    f"Could not determine GoAnywhere version for {target.origin}"
+                )
+                return vulnerabilities
+
+            # Check if version is vulnerable
+            if self._is_vulnerable_version(detected_version) is True:
+                vuln = self.create_vulnerability(target)
+                vuln.technical_detail = (
+                    f"{target.origin} is running GoAnywhere MFT version {detected_version} "
+                    f"which is vulnerable to {VULNERABILITY_REFERENCE}. This version contains "
+                    f"a deserialization vulnerability in the License Servlet that allows "
+                    f"remote code execution."
+                )
+                vulnerabilities.append(vuln)
+                logger.info(
+                    f"Vulnerable GoAnywhere MFT found: {target.origin} (v{detected_version})"
+                )
+            else:
+                logger.info(
+                    f"GoAnywhere MFT at {target.origin} (v{detected_version}) is not vulnerable"
+                )
+
+        except requests_exceptions.RequestException as e:
+            logger.error(f"Vulnerability check failed for {target.origin}: {e}")
+
+        return vulnerabilities
+
+    def _is_goanywhere_response(self, response_text: str | None = None) -> bool:
+        """
+        Check if response text indicates GoAnywhere MFT.
+
+        Args:
+            response_text: HTTP response content
+
+        Returns:
+            True if response indicates GoAnywhere MFT
+        """
+        if response_text is None or response_text.strip() == "":
+            return False
+
+        try:
+            for pattern in GOANYWHERE_PATTERNS:
+                if re.search(pattern, response_text, re.IGNORECASE) is not None:
+                    return True
+            return False
+        except re.error as e:
+            logger.error(f"Regex error in GoAnywhere detection: {e}")
+            return False
+
+    def _extract_version(self, response_text: str) -> Optional[str]:
+        """
+        Extract GoAnywhere version from response text.
+
+        Args:
+            response_text: HTTP response content
+
+        Returns:
+            Version string if found, None otherwise
+        """
+        if response_text is None or response_text.strip() == "":
+            return None
+
+        try:
+            match = VERSION_PATTERN.search(response_text)
+            if match is not None:
+                return match.group(1)
+            return None
+        except re.error as e:
+            logger.error(f"Regex error in version extraction: {e}")
+            return None
+
+    def _is_vulnerable_version(self, version_string: str) -> bool:
+        """
+        Check if the given version is vulnerable to CVE-2025-10035.
+
+        Args:
+            version_string: Version string to check
+
+        Returns:
+            True if version is vulnerable, False otherwise
+        """
+        try:
+            ver = version.parse(version_string)
+
+            # Check latest branch vulnerability range (7.7.0 <= version <= 7.8.4)
+            if LATEST_MIN <= ver <= LATEST_MAX:
+                return True
+
+            # Check sustained support branch vulnerability (version < 7.6.3)
+            if ver < SUSTAIN_MAX:
+                return True
+
+            return False
+
+        except (ValueError, TypeError) as e:
+            logger.error(f"Error parsing version '{version_string}': {e}")
+            return False

--- a/tests/exploits/cve_2025_10035_test.py
+++ b/tests/exploits/cve_2025_10035_test.py
@@ -1,6 +1,7 @@
 """Unit tests for GoAnywhereDeserializationExploit: CVE-2025-10035"""
 
 from unittest import mock
+import requests.exceptions
 from agent.exploits import cve_2025_10035
 from agent import definitions
 
@@ -10,75 +11,90 @@ def testCheck_WhenVulnerableVersion_ShouldReportVulnerability() -> None:
     exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
     target = definitions.Target("https", "localhost", 443)
     mock_response = mock.Mock()
-    mock_response.text = "GoAnywhere 7.7.0"
+    mock_response.text = """
+    <html>
+        <title>GoAnywhere MFT Login</title>
+        <body>
+            <h1>GoAnywhere 7.7.0</h1>
+            <form>Login form here</form>
+        </body>
+    </html>
+    """
     mock_response.status_code = 200
 
-    with (
-        mock.patch.object(exploit.session, "get", return_value=mock_response),
-        mock.patch.object(
-            cve_2025_10035.GoAnywhereDeserializationExploit,
-            "_extract_version",
-            return_value="7.7.0",
-        ),
-        mock.patch.object(
-            cve_2025_10035.GoAnywhereDeserializationExploit,
-            "_is_goanywhere_response",
-            return_value=True,
-        ),
-    ):
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
         vulns = exploit.check(target)
 
         assert len(vulns) == 1
         assert "7.7.0" in vulns[0].technical_detail
+        assert cve_2025_10035.VULNERABILITY_REFERENCE in vulns[0].technical_detail
 
 
-def testCheckWhen_NotVulnerableVersion_ShouldNotReportVulnerability() -> None:
+def testCheck_WhenNotVulnerableVersion_ShouldNotReportVulnerability() -> None:
     """Test check method with a non-vulnerable GoAnywhere version."""
     exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
     target = definitions.Target("https", "localhost", 443)
     mock_response = mock.Mock()
-    mock_response.text = "GoAnywhere 7.8.5"
+    mock_response.text = """
+    <html>
+        <title>GoAnywhere MFT Login</title>
+        <body>
+            <h1>GoAnywhere 7.8.5</h1>
+            <form>Login form here</form>
+        </body>
+    </html>
+    """
     mock_response.status_code = 200
 
-    with (
-        mock.patch.object(exploit.session, "get", return_value=mock_response),
-        mock.patch.object(
-            cve_2025_10035.GoAnywhereDeserializationExploit,
-            "_extract_version",
-            return_value="7.8.5",
-        ),
-        mock.patch.object(
-            cve_2025_10035.GoAnywhereDeserializationExploit,
-            "_is_goanywhere_response",
-            return_value=True,
-        ),
-    ):
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
         vulns = exploit.check(target)
 
         assert len(vulns) == 0
 
 
-def testCheck_WhenInvalidVersion_ShouldNotReportVulnerability() -> None:
-    """Test check method with an invalid version string."""
+def testCheck_WhenSustainedSupportVulnerable_ShouldReportVulnerability() -> None:
+    """Test check method with a vulnerable sustained support version."""
     exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
     target = definitions.Target("https", "localhost", 443)
     mock_response = mock.Mock()
-    mock_response.text = "GoAnywhere not.a.version"
+    mock_response.text = """
+    <html>
+        <title>GoAnywhere MFT Login</title>
+        <body>
+            <div>GoAnywhere 7.6.2</div>
+            <form>Login form here</form>
+        </body>
+    </html>
+    """
     mock_response.status_code = 200
 
-    with (
-        mock.patch.object(exploit.session, "get", return_value=mock_response),
-        mock.patch.object(
-            cve_2025_10035.GoAnywhereDeserializationExploit,
-            "_extract_version",
-            return_value="not.a.version",
-        ),
-        mock.patch.object(
-            cve_2025_10035.GoAnywhereDeserializationExploit,
-            "_is_goanywhere_response",
-            return_value=True,
-        ),
-    ):
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 1
+        assert "7.6.2" in vulns[0].technical_detail
+
+
+def testCheck_WhenInvalidVersion_ShouldNotReportVulnerability() -> None:
+    """Test check method when version cannot be extracted."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+
+    # Mock response containing GoAnywhere but no valid version
+    mock_response = mock.Mock()
+    mock_response.text = """
+    <html>
+        <title>GoAnywhere MFT Login</title>
+        <body>
+            <h1>GoAnywhere Managed File Transfer</h1>
+            <p>Version information not available</p>
+            <form>Login form here</form>
+        </body>
+    </html>
+    """
+    mock_response.status_code = 200
+
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
         vulns = exploit.check(target)
 
         assert len(vulns) == 0
@@ -89,17 +105,94 @@ def testCheck_WhenNotGoAnywhereResponse_ShouldNotReportVulnerability() -> None:
     exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
     target = definitions.Target("https", "localhost", 443)
     mock_response = mock.Mock()
-    mock_response.text = "Some other product"
+    mock_response.text = """
+    <html>
+        <title>Apache Tomcat</title>
+        <body>
+            <h1>Apache Tomcat Manager</h1>
+            <p>Welcome to the Tomcat Manager</p>
+        </body>
+    </html>
+    """
     mock_response.status_code = 200
 
-    with (
-        mock.patch.object(exploit.session, "get", return_value=mock_response),
-        mock.patch.object(
-            cve_2025_10035.GoAnywhereDeserializationExploit,
-            "_is_goanywhere_response",
-            return_value=False,
-        ),
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0
+
+
+def testCheck_WhenRequestException_ShouldNotReportVulnerability() -> None:
+    """Test check method when HTTP request fails."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+
+    with mock.patch.object(
+        exploit.session,
+        "get",
+        side_effect=requests.exceptions.ConnectionError("Connection refused"),
     ):
         vulns = exploit.check(target)
 
         assert len(vulns) == 0
+
+
+def testAccept_WhenGoAnywhereDetected_ShouldReturnTrue() -> None:
+    """Test accept method when GoAnywhere is detected."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+
+    # Mock response containing GoAnywhere patterns
+    mock_response = mock.Mock()
+    mock_response.text = """
+    <html>
+        <title>GoAnywhere MFT Login</title>
+        <body>
+            <h1>Fortra GoAnywhere Managed File Transfer</h1>
+        </body>
+    </html>
+    """
+    mock_response.status_code = 200
+
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
+        result = exploit.accept(target)
+
+        assert result is True
+
+
+def testAccept_WhenGoAnywhereNotDetected_ShouldReturnFalse() -> None:
+    """Test accept method when GoAnywhere is not detected."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+
+    # Mock response from different product
+    mock_response = mock.Mock()
+    mock_response.text = """
+    <html>
+        <title>FileZilla Server</title>
+        <body>
+            <h1>FileZilla Server Web Interface</h1>
+        </body>
+    </html>
+    """
+    mock_response.status_code = 200
+
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
+        result = exploit.accept(target)
+
+        assert result is False
+
+
+def testAccept_WhenRequestException_ShouldReturnFalse() -> None:
+    """Test accept method when HTTP request fails."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+
+    with mock.patch.object(
+        exploit.session,
+        "get",
+        side_effect=requests.exceptions.Timeout("Request timeout"),
+    ):
+        result = exploit.accept(target)
+
+        assert result is False

--- a/tests/exploits/cve_2025_10035_test.py
+++ b/tests/exploits/cve_2025_10035_test.py
@@ -1,5 +1,6 @@
 """Unit tests for GoAnywhereDeserializationExploit: CVE-2025-10035"""
 
+import re
 from unittest import mock
 import requests.exceptions
 from agent.exploits import cve_2025_10035
@@ -141,8 +142,6 @@ def testAccept_WhenGoAnywhereDetected_ShouldReturnTrue() -> None:
     """Test accept method when GoAnywhere is detected."""
     exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
     target = definitions.Target("https", "localhost", 443)
-
-    # Mock response containing GoAnywhere patterns
     mock_response = mock.Mock()
     mock_response.text = """
     <html>
@@ -164,8 +163,6 @@ def testAccept_WhenGoAnywhereNotDetected_ShouldReturnFalse() -> None:
     """Test accept method when GoAnywhere is not detected."""
     exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
     target = definitions.Target("https", "localhost", 443)
-
-    # Mock response from different product
     mock_response = mock.Mock()
     mock_response.text = """
     <html>
@@ -196,3 +193,175 @@ def testAccept_WhenRequestException_ShouldReturnFalse() -> None:
         result = exploit.accept(target)
 
         assert result is False
+
+
+def testCheck_WhenEmptyResponseText_ShouldNotReportVulnerability() -> None:
+    """Test check method when response text is empty string."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = ""
+    mock_response.status_code = 200
+
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0
+
+
+def testCheck_WhenWhitespaceOnlyResponseText_ShouldNotReportVulnerability() -> None:
+    """Test check method when response text contains only whitespace."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "   \n\t  \r\n  "
+    mock_response.status_code = 200
+
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0
+
+
+def testCheck_WhenNoneResponseText_ShouldNotReportVulnerability() -> None:
+    """Test check method when response text is None."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = None
+    mock_response.status_code = 200
+
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0
+
+
+def testAccept_WhenEmptyResponseText_ShouldReturnFalse() -> None:
+    """Test accept method when response text is empty."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = ""
+    mock_response.status_code = 200
+
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
+        result = exploit.accept(target)
+
+        assert result is False
+
+
+def testAccept_WhenNoneResponseText_ShouldReturnFalse() -> None:
+    """Test accept method when response text is None."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = None
+    mock_response.status_code = 200
+
+    with mock.patch.object(exploit.session, "get", return_value=mock_response):
+        result = exploit.accept(target)
+
+        assert result is False
+
+
+def testCheck_WhenRegexErrorInGoAnywhereDetection_ShouldNotReportVulnerability() -> (
+    None
+):
+    """Test check method when regex error occurs during GoAnywhere detection."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "GoAnywhere MFT Login"
+    mock_response.status_code = 200
+
+    with (
+        mock.patch.object(exploit.session, "get", return_value=mock_response),
+        mock.patch("re.search", side_effect=re.error("Invalid regex pattern")),
+    ):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0
+
+
+def testAccept_WhenRegexErrorInGoAnywhereDetection_ShouldReturnFalse() -> None:
+    """Test accept method when regex error occurs during GoAnywhere detection."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "GoAnywhere MFT Login"
+    mock_response.status_code = 200
+
+    with (
+        mock.patch.object(exploit.session, "get", return_value=mock_response),
+        mock.patch("re.search", side_effect=re.error("Invalid regex pattern")),
+    ):
+        result = exploit.accept(target)
+
+        assert result is False
+
+
+def testCheck_WhenRegexErrorInVersionExtraction_ShouldNotReportVulnerability() -> None:
+    """Test check method when regex error occurs during version extraction."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "GoAnywhere MFT 7.7.0"
+    mock_response.status_code = 200
+
+    def mock_re_search(pattern: str, string: str, flags: int = 0) -> mock.Mock | None:
+        for goa_pattern in cve_2025_10035.GOANYWHERE_PATTERNS:
+            if pattern == goa_pattern:
+                return mock.Mock()
+
+        if "GoAnywhere" in str(pattern) and "([0-9]" in str(pattern):
+            raise re.error("Invalid regex in version pattern")
+
+        return None
+
+    with (
+        mock.patch.object(exploit.session, "get", return_value=mock_response),
+        mock.patch("re.search", side_effect=mock_re_search),
+    ):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0
+
+
+def testCheck_WhenValueErrorInVersionParsing_ShouldNotReportVulnerability() -> None:
+    """Test check method when ValueError occurs during version parsing."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "GoAnywhere MFT 7.7.invalid"
+    mock_response.status_code = 200
+
+    with (
+        mock.patch.object(exploit.session, "get", return_value=mock_response),
+        mock.patch(
+            "packaging.version.parse", side_effect=ValueError("Invalid version format")
+        ),
+    ):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0
+
+
+def testCheck_WhenTypeErrorInVersionParsing_ShouldNotReportVulnerability() -> None:
+    """Test check method when TypeError occurs during version parsing."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "GoAnywhere MFT 7.7.0"
+    mock_response.status_code = 200
+
+    with (
+        mock.patch.object(exploit.session, "get", return_value=mock_response),
+        mock.patch(
+            "packaging.version.parse",
+            side_effect=TypeError("Type error in version parsing"),
+        ),
+    ):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0

--- a/tests/exploits/cve_2025_10035_test.py
+++ b/tests/exploits/cve_2025_10035_test.py
@@ -1,0 +1,105 @@
+"""Unit tests for GoAnywhereDeserializationExploit: CVE-2025-10035"""
+
+from unittest import mock
+from agent.exploits import cve_2025_10035
+from agent import definitions
+
+
+def testCheck_WhenVulnerableVersion_ShouldReportVulnerability() -> None:
+    """Test check method with a vulnerable GoAnywhere version."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "GoAnywhere 7.7.0"
+    mock_response.status_code = 200
+
+    with (
+        mock.patch.object(exploit.session, "get", return_value=mock_response),
+        mock.patch.object(
+            cve_2025_10035.GoAnywhereDeserializationExploit,
+            "_extract_version",
+            return_value="7.7.0",
+        ),
+        mock.patch.object(
+            cve_2025_10035.GoAnywhereDeserializationExploit,
+            "_is_goanywhere_response",
+            return_value=True,
+        ),
+    ):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 1
+        assert "7.7.0" in vulns[0].technical_detail
+
+
+def testCheckWhen_NotVulnerableVersion_ShouldNotReportVulnerability() -> None:
+    """Test check method with a non-vulnerable GoAnywhere version."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "GoAnywhere 7.8.5"
+    mock_response.status_code = 200
+
+    with (
+        mock.patch.object(exploit.session, "get", return_value=mock_response),
+        mock.patch.object(
+            cve_2025_10035.GoAnywhereDeserializationExploit,
+            "_extract_version",
+            return_value="7.8.5",
+        ),
+        mock.patch.object(
+            cve_2025_10035.GoAnywhereDeserializationExploit,
+            "_is_goanywhere_response",
+            return_value=True,
+        ),
+    ):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0
+
+
+def testCheck_WhenInvalidVersion_ShouldNotReportVulnerability() -> None:
+    """Test check method with an invalid version string."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "GoAnywhere not.a.version"
+    mock_response.status_code = 200
+
+    with (
+        mock.patch.object(exploit.session, "get", return_value=mock_response),
+        mock.patch.object(
+            cve_2025_10035.GoAnywhereDeserializationExploit,
+            "_extract_version",
+            return_value="not.a.version",
+        ),
+        mock.patch.object(
+            cve_2025_10035.GoAnywhereDeserializationExploit,
+            "_is_goanywhere_response",
+            return_value=True,
+        ),
+    ):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0
+
+
+def testCheck_WhenNotGoAnywhereResponse_ShouldNotReportVulnerability() -> None:
+    """Test check method with a response that is not GoAnywhere."""
+    exploit = cve_2025_10035.GoAnywhereDeserializationExploit()
+    target = definitions.Target("https", "localhost", 443)
+    mock_response = mock.Mock()
+    mock_response.text = "Some other product"
+    mock_response.status_code = 200
+
+    with (
+        mock.patch.object(exploit.session, "get", return_value=mock_response),
+        mock.patch.object(
+            cve_2025_10035.GoAnywhereDeserializationExploit,
+            "_is_goanywhere_response",
+            return_value=False,
+        ),
+    ):
+        vulns = exploit.check(target)
+
+        assert len(vulns) == 0


### PR DESCRIPTION
This pull request introduces detection logic and unit tests for CVE-2025-10035, a critical deserialization vulnerability in the License Servlet of Fortra's GoAnywhere MFT. The vulnerability allows remote attackers to execute arbitrary code via crafted serialized data, affecting multiple version ranges of GoAnywhere MFT. The detection is implemented as part of the Agent Asteroid project.

## Details
- **Vulnerability Title:** GoAnywhere MFT License Servlet Deserialization Vulnerability
- **CVE:** CVE-2025-10035
- **Risk Rating:** CRITICAL
- **Description:**
    - A deserialization vulnerability in the License Servlet of Fortra's GoAnywhere MFT allows remote attackers to execute arbitrary code via crafted serialized data. This vulnerability affects multiple version ranges and can be exploited without authentication.
- **Recommendation:**
    - Update GoAnywhere MFT to version 7.8.5 or later.
    - If using sustained support versions, upgrade beyond 7.6.3.
    - Apply security patches from Fortra.
    - Monitor network traffic for exploitation attempts.
    - Implement network segmentation to limit access to GoAnywhere MFT instances.

## Implementation
- Added `GoAnywhereDeserializationExploit` class in `agent/exploits/cve_2025_10035.py`.
- Implements detection logic for vulnerable GoAnywhere MFT instances by:
    - Identifying GoAnywhere MFT via HTTP response patterns.
    - Extracting version information from server responses.
    - Checking if the detected version falls within the vulnerable ranges.
- Handles error cases and logs warnings if version extraction fails.
- 
## Testing
- Unit tests are provided in `tests/exploits/cve_2025_10035_test.py`.
- Tests cover:
    - Detection of vulnerable and non-vulnerable versions.
    - Handling of invalid or missing version information.
    - Non-GoAnywhere responses.