### PR TITLE
fix: when no custom CVE list is provided, the agent loads all available exploits

### DIFF
--- a/agent/asteroid_agent.py
+++ b/agent/asteroid_agent.py
@@ -61,12 +61,12 @@ class AsteroidAgent(
 
         exploits.import_all()
 
-        custom_cve_list: list[str] | None = self.args.get("custom_cve_list")
+        custom_cve_list: list[str] = self.args.get("custom_cve_list") or []
 
         self.exploits: list[definitions.Exploit] = []
         all_exploits = exploits_registry.ExploitsRegistry.values()
 
-        if custom_cve_list is None:
+        if len(custom_cve_list) == 0:
             self.exploits = all_exploits
         else:
             result_exploit = set()

--- a/tests/asteroid_agent_test.py
+++ b/tests/asteroid_agent_test.py
@@ -172,3 +172,20 @@ def testAgent_whenCustomCVEsMatchCVEIDsInMetadatabutNotPluginName_shouldScanOnly
         assert "CVE-2025-27364" in found_cves
         assert "CVE-2025-48828" in found_cves
         assert "CVE-2018-10562" in found_cves
+
+
+def testAgent_whenNoCustomCVEPassed_shouldSetAllExploits() -> None:
+    """Ensure that when no custom CVE list is provided, the agent loads all available exploits."""
+    with (pathlib.Path(__file__).parent.parent / "ostorlab.yaml").open() as yaml_o:
+        definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
+        settings = runtime_definitions.AgentSettings(
+            key="agent/ostorlab/asteroid",
+            bus_url="NA",
+            bus_exchange_topic="NA",
+            args=[],
+            healthcheck_port=5301,
+            redis_url="redis://guest:guest@localhost:6379",
+        )
+        agent = asteroid_agent.AsteroidAgent(definition, settings)
+
+        assert len(agent.exploits) == 116


### PR DESCRIPTION
fix: when no custom CVE list is provided, the agent loads all available exploits