### PR TITLE
feature: handle-schema-message

### DIFF
--- a/agent/asteroid_agent.py
+++ b/agent/asteroid_agent.py
@@ -1,5 +1,5 @@
 """Asteroid Agent is designed to identify known exploitable vulnerabilities in a remote system. The agent expects a
-message of type `v3.asset.ip.[v4,v6]`, `v3.asset.[domain_name,link]`, or `v3.asset.file.api_schema`, and emits back 
+message of type `v3.asset.ip.[v4,v6]`, `v3.asset.[domain_name,link]`, or `v3.asset.file.api_schema`, and emits back
 messages of type `v3.report.vulnerability` with a technical report."""
 
 import ipaddress
@@ -84,7 +84,11 @@ class AsteroidAgent(
 
     def _is_target_already_processed(self, message: m.Message) -> bool:
         """Checks if the target has already been processed before"""
-        if message.data.get("url") is not None or message.data.get("name") is not None or message.data.get("endpoint_url") is not None:
+        if (
+            message.data.get("url") is not None
+            or message.data.get("name") is not None
+            or message.data.get("endpoint_url") is not None
+        ):
             unicity_check_key = f"{message.data.get('url') or message.data.get('name') or message.data.get('endpoint_url')}"
             return self.set_is_member(key=ASTEROID_AGENT_KEY, value=unicity_check_key)
 
@@ -102,7 +106,11 @@ class AsteroidAgent(
 
     def _mark_target_as_processed(self, message: m.Message) -> None:
         """Mark the target as processed"""
-        if message.data.get("url") is not None or message.data.get("name") is not None or message.data.get("endpoint_url") is not None:
+        if (
+            message.data.get("url") is not None
+            or message.data.get("name") is not None
+            or message.data.get("endpoint_url") is not None
+        ):
             unicity_check_key = f"{message.data.get('url') or message.data.get('name') or message.data.get('endpoint_url')}"
             self.set_add(ASTEROID_AGENT_KEY, unicity_check_key)
         elif message.data.get("host") is not None:
@@ -115,7 +123,7 @@ class AsteroidAgent(
                 self.set_add(ASTEROID_AGENT_KEY, host)
 
     def process(self, message: m.Message) -> None:
-        """Process messages of type `v3.asset.ip.[v4,v6]`, `v3.asset.[domain_name,link]`, or 
+        """Process messages of type `v3.asset.ip.[v4,v6]`, `v3.asset.[domain_name,link]`, or
         `v3.asset.file.api_schema` and performs a network scan. Once the scan is completed, it emits messages of type
         `v3.report.vulnerability` with the technical report.
 

--- a/agent/asteroid_agent.py
+++ b/agent/asteroid_agent.py
@@ -1,6 +1,6 @@
 """Asteroid Agent is designed to identify known exploitable vulnerabilities in a remote system. The agent expects a
-message of type `v3.asset.ip.[v4,v6]` or `v3.asset.[domain_name,link]`, and emits back messages of type
-`v3.report.vulnerability` with a technical report."""
+message of type `v3.asset.ip.[v4,v6]`, `v3.asset.[domain_name,link]`, or `v3.asset.file.api_schema`, and emits back 
+messages of type `v3.report.vulnerability` with a technical report."""
 
 import ipaddress
 import logging
@@ -84,8 +84,8 @@ class AsteroidAgent(
 
     def _is_target_already_processed(self, message: m.Message) -> bool:
         """Checks if the target has already been processed before"""
-        if message.data.get("url") is not None or message.data.get("name") is not None:
-            unicity_check_key = f"{message.data.get('url') or message.data.get('name')}"
+        if message.data.get("url") is not None or message.data.get("name") is not None or message.data.get("endpoint_url") is not None:
+            unicity_check_key = f"{message.data.get('url') or message.data.get('name') or message.data.get('endpoint_url')}"
             return self.set_is_member(key=ASTEROID_AGENT_KEY, value=unicity_check_key)
 
         if message.data.get("host") is not None:
@@ -102,8 +102,8 @@ class AsteroidAgent(
 
     def _mark_target_as_processed(self, message: m.Message) -> None:
         """Mark the target as processed"""
-        if message.data.get("url") is not None or message.data.get("name") is not None:
-            unicity_check_key = f"{message.data.get('url') or message.data.get('name')}"
+        if message.data.get("url") is not None or message.data.get("name") is not None or message.data.get("endpoint_url") is not None:
+            unicity_check_key = f"{message.data.get('url') or message.data.get('name') or message.data.get('endpoint_url')}"
             self.set_add(ASTEROID_AGENT_KEY, unicity_check_key)
         elif message.data.get("host") is not None:
             host = str(message.data.get("host"))
@@ -115,8 +115,8 @@ class AsteroidAgent(
                 self.set_add(ASTEROID_AGENT_KEY, host)
 
     def process(self, message: m.Message) -> None:
-        """Process messages of type `v3.asset.ip.[v4,v6]` or `v3.asset.[domain_name,link]` and performs a network
-        scan. Once the scan is completed, it emits messages of type
+        """Process messages of type `v3.asset.ip.[v4,v6]`, `v3.asset.[domain_name,link]`, or 
+        `v3.asset.file.api_schema` and performs a network scan. Once the scan is completed, it emits messages of type
         `v3.report.vulnerability` with the technical report.
 
         Args:

--- a/agent/targets_preparer.py
+++ b/agent/targets_preparer.py
@@ -110,5 +110,17 @@ def prepare_targets(message: m.Message) -> Generator[definitions.Target, None, N
                 "Incomplete target configuration: host, port, and scheme must all be provided."
                 f"\nhost: {host}\nport: {port}\nscheme: {scheme}"
             )
+    elif (endpoint_url := message.data.get("endpoint_url")) is not None:
+        parsed_url = urlparse(endpoint_url)
+        host = parsed_url.hostname
+        port = parsed_url.port or _get_port(message, parsed_url.scheme)
+        scheme = parsed_url.scheme or "https"
+        if host is not None and port is not None and scheme is not None:
+            yield (definitions.Target(host=host, port=port, scheme=scheme))
+        else:
+            logger.warning(
+                "Incomplete target configuration: host, port, and scheme must all be provided."
+                f"\nhost: {host}\nport: {port}\nscheme: {scheme}"
+            )
     else:
         logger.warning(f"Invalid message format\nmessage: {message}")

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -70,6 +70,7 @@ in_selectors:
   - v3.asset.ip.v6
   - v3.asset.domain_name
   - v3.asset.link
+  - v3.asset.file.api_schema
 out_selectors:
   - v3.report.vulnerability
 supported_architectures:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,14 @@ def scan_message_link() -> message.Message:
 
 
 @pytest.fixture()
+def scan_message_api_schema() -> message.Message:
+    """Creates a message of type v3.asset.file.api_schema to be used by the agent for testing purposes."""
+    selector = "v3.asset.file.api_schema"
+    msg_data = {"endpoint_url": "https://api.example.com/v1/users", "schema_type": "openapi"}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
 def scan_message_ipv6() -> message.Message:
     """Creates a message of type v3.asset.ip.v6 to be used by the agent for testing purposes."""
     selector = "v3.asset.ip.v6"
@@ -159,6 +167,17 @@ def scan_bad_message() -> message.Message:
             "url": "https://example.com/index.html",
             "method": "GET",
         },
+    }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
+def scan_bad_api_schema_message() -> message.Message:
+    """Creates a bad message of type v3.asset.file.api_schema with invalid endpoint_url."""
+    selector = "v3.asset.file.api_schema"
+    msg_data = {
+        "endpoint_url": "javascript: alert('xss')",
+        "schema_type": "openapi",
     }
     return message.Message.from_data(selector, data=msg_data)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,10 @@ def scan_message_link() -> message.Message:
 def scan_message_api_schema() -> message.Message:
     """Creates a message of type v3.asset.file.api_schema to be used by the agent for testing purposes."""
     selector = "v3.asset.file.api_schema"
-    msg_data = {"endpoint_url": "https://api.example.com/v1/users", "schema_type": "openapi"}
+    msg_data = {
+        "endpoint_url": "https://api.example.com/v1/users",
+        "schema_type": "openapi",
+    }
     return message.Message.from_data(selector, data=msg_data)
 
 

--- a/tests/targets_preparer_test.py
+++ b/tests/targets_preparer_test.py
@@ -50,6 +50,17 @@ def testPrepareTargets_whenLinkAsset_returnResult(
         assert target.port == 443
 
 
+def testPrepareTargets_whenApiSchemaAsset_returnResult(
+    scan_message_api_schema: message.Message,
+) -> None:
+    targets = targets_preparer.prepare_targets(scan_message_api_schema)
+
+    for target in targets:
+        assert target.host == "api.example.com"
+        assert target.scheme == "https"
+        assert target.port == 443
+
+
 def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
     scan_message_ipv4_with_mask8: message.Message,
 ) -> None:
@@ -80,5 +91,13 @@ def testPrepareTargets_whenInvalidMessage_returnEmptyTargets(
     scan_bad_message: message.Message,
 ) -> None:
     targets = targets_preparer.prepare_targets(scan_bad_message)
+
+    assert any(targets) is False
+
+
+def testPrepareTargets_whenBadApiSchemaMessage_returnEmptyTargets(
+    scan_bad_api_schema_message: message.Message,
+) -> None:
+    targets = targets_preparer.prepare_targets(scan_bad_api_schema_message)
 
     assert any(targets) is False


### PR DESCRIPTION
This PR adds support for processing API schema assets (`v3.asset.file.api_schema`) to the Asteroid Agent. The agent can now extract target information from schema endpoints in addition to the existing IP, domain, and link asset types.

- Added endpoint URL parsing logic to extract host, port, and scheme from API schema messages
- Updated deduplication logic to track API schema endpoints
- Added test coverage for both valid and invalid API schema messages