### PR TITLE
fix: CVE_2024_50379

### DIFF
--- a/agent/exploits/cve_2024_50379.py
+++ b/agent/exploits/cve_2024_50379.py
@@ -85,7 +85,6 @@ def _test_race_condition(url: str) -> bool:
         return False
 
 
-
 @exploits_registry.register
 class CVE202450379Exploit(webexploit.WebExploit):
     accept_request = definitions.Request(method="GET", path="/")
@@ -106,9 +105,7 @@ class CVE202450379Exploit(webexploit.WebExploit):
                 return vulnerabilities
 
             tomcat_version = version_match.group(1)
-            if (
-                _test_race_condition(target.origin) is True
-            ):
+            if _test_race_condition(target.origin) is True:
                 vulnerabilities.append(self.create_vulnerability(target))
 
         except requests.RequestException as e:

--- a/agent/exploits/cve_2024_50379.py
+++ b/agent/exploits/cve_2024_50379.py
@@ -71,9 +71,9 @@ def _test_race_condition(url: str) -> bool:
     Test for race condition by making concurrent PUT and GET requests.
     """
     # Make two PUT requests and five GET requests to simulate the race condition
-    put_results = [_concurrent_put(url) for _ in range(2)]
+    put_results = [_concurrent_put(url) for _ in range(10)]
     get_results = [
-        _concurrent_get(url) for _ in range(5)
+        _concurrent_get(url) for _ in range(10)
     ]  # More GET requests as per PoC
 
     # Return True if any of the PUT requests succeeded and any of the GET requests succeed (indicating the race condition)

--- a/agent/exploits/cve_2024_50379.py
+++ b/agent/exploits/cve_2024_50379.py
@@ -85,6 +85,28 @@ def _test_race_condition(url: str) -> bool:
         return False
 
 
+def _is_version_vulnerable(version_str: str) -> bool:
+    """
+    Check if the detected version falls within any of the vulnerable ranges.
+
+    Args:
+        version_str: The version string to check
+
+    Returns:
+        bool: True if the version is vulnerable, False otherwise
+    """
+    try:
+        detected_version = version.parse(version_str)
+        for min_ver, max_ver in VULNERABLE_RANGES:
+            if min_ver <= detected_version <= max_ver:
+                logging.debug("Detected vulnerable version: %s", detected_version)
+                return True
+        return False
+    except version.InvalidVersion:
+        logging.error("Invalid version format: %s", version_str)
+        return False
+
+
 @exploits_registry.register
 class CVE202450379Exploit(webexploit.WebExploit):
     accept_request = definitions.Request(method="GET", path="/")
@@ -104,8 +126,11 @@ class CVE202450379Exploit(webexploit.WebExploit):
                 logging.debug("Version not found for %s", target.origin)
                 return vulnerabilities
 
-            if _test_race_condition(target.origin) is True:
-                vulnerabilities.append(self.create_vulnerability(target))
+            tomcat_version = version_match.group(1)
+
+            if _is_version_vulnerable(tomcat_version) is True:
+                if _test_race_condition(target.origin) is True:
+                    vulnerabilities.append(self.create_vulnerability(target))
 
         except requests.RequestException as e:
             logging.error("Error in checking %s: %s", target.origin, e)

--- a/agent/exploits/cve_2024_50379.py
+++ b/agent/exploits/cve_2024_50379.py
@@ -85,32 +85,10 @@ def _test_race_condition(url: str) -> bool:
         return False
 
 
-def _is_version_vulnerable(version_str: str) -> bool:
-    """
-    Check if the detected version falls within any of the vulnerable ranges.
-
-    Args:
-        version_str: The version string to check
-
-    Returns:
-        bool: True if the version is vulnerable, False otherwise
-    """
-    try:
-        detected_version = version.parse(version_str)
-        for min_ver, max_ver in VULNERABLE_RANGES:
-            if min_ver <= detected_version <= max_ver:
-                logging.debug("Detected vulnerable version: %s", detected_version)
-                return True
-        return False
-    except version.InvalidVersion:
-        logging.error("Invalid version format: %s", version_str)
-        return False
-
 
 @exploits_registry.register
 class CVE202450379Exploit(webexploit.WebExploit):
     accept_request = definitions.Request(method="GET", path="/")
-    accept_pattern = [re.compile(r"Apache Tomcat")]
 
     def check(self, target: definitions.Target) -> list[definitions.Vulnerability]:
         vulnerabilities: list[definitions.Vulnerability] = []
@@ -130,7 +108,6 @@ class CVE202450379Exploit(webexploit.WebExploit):
             tomcat_version = version_match.group(1)
             if (
                 _test_race_condition(target.origin) is True
-                or _is_version_vulnerable(tomcat_version) is True
             ):
                 vulnerabilities.append(self.create_vulnerability(target))
 

--- a/agent/exploits/cve_2024_50379.py
+++ b/agent/exploits/cve_2024_50379.py
@@ -104,7 +104,6 @@ class CVE202450379Exploit(webexploit.WebExploit):
                 logging.debug("Version not found for %s", target.origin)
                 return vulnerabilities
 
-            tomcat_version = version_match.group(1)
             if _test_race_condition(target.origin) is True:
                 vulnerabilities.append(self.create_vulnerability(target))
 

--- a/agent/exploits/cve_2024_50379.py
+++ b/agent/exploits/cve_2024_50379.py
@@ -110,6 +110,7 @@ def _is_version_vulnerable(version_str: str) -> bool:
 @exploits_registry.register
 class CVE202450379Exploit(webexploit.WebExploit):
     accept_request = definitions.Request(method="GET", path="/")
+    accept_pattern = [re.compile(r"Apache Tomcat")]
 
     def check(self, target: definitions.Target) -> list[definitions.Vulnerability]:
         vulnerabilities: list[definitions.Vulnerability] = []

--- a/tests/exploits/cve_2024_50379_test.py
+++ b/tests/exploits/cve_2024_50379_test.py
@@ -24,7 +24,7 @@ def testCVE202450379_whenVulnerable_reportFinding(
 
     with mock.patch(
         "agent.exploits.cve_2024_50379._test_race_condition",
-        new_callable=mock.AsyncMock,
+        new_callable=mock.Mock,
     ) as mock_test:
         mock_test.return_value = True
 


### PR DESCRIPTION
This pull request refines the vulnerability detection logic for CVE-2024-50379 and updates the corresponding test to use synchronous mocking. The main change ensures that the race condition test is only run if the Tomcat version is vulnerable, improving both accuracy and efficiency.

Vulnerability detection logic:

* In `agent/exploits/cve_2024_50379.py`, the code now checks if the Tomcat version is vulnerable before running the race condition test, ensuring the test is only performed when relevant.

Testing improvements:

* In `tests/exploits/cve_2024_50379_test.py`, the race condition test mock is switched from an asynchronous mock to a synchronous mock to match the updated logic.