### PR TITLE
fix: upgrade to python3.14

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ requirements.txt
 tests
 ruff.toml
 README.md
+venv
+.venv

--- a/.github/workflows/lint_format_checker.yaml
+++ b/.github/workflows/lint_format_checker.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.14" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/typing_checker.yaml
+++ b/.github/workflows/typing_checker.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.14" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim as base
+FROM python:3.14-slim as base
 RUN apt-get update && apt-get install -y \
     default-jdk \
     g++ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,39 @@
 FROM python:3.14-slim as base
+
 RUN apt-get update && apt-get install -y \
     default-jdk \
-    g++ \
     libpq-dev \
+    libffi-dev \
     --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV CLASSPATH=/app/agent/Resources/hsqldb.jar:$CLASSPATH
-FROM base as builder
-RUN mkdir /install
-WORKDIR /install
-COPY requirement.txt /requirement.txt
-RUN pip install uv
-RUN uv pip install --prefix=/install -r /requirement.txt
-FROM base
-COPY --from=builder /install /usr/local
-RUN mkdir -p /app/agent
 ENV PYTHONPATH=/app
+
+FROM base as builder
+
+RUN apt-get update && apt-get install -y \
+    g++ \
+    make \
+    cmake \
+    pkg-config \
+    libc6-dev \
+    --no-install-recommends
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /install
+COPY requirement.txt .
+RUN uv pip install --prefix=/install -r requirement.txt --system
+
+FROM base
+
+COPY --from=builder /install /usr/local
+
+RUN mkdir -p /app/agent
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
+
 WORKDIR /app
 CMD ["python3", "/app/agent/asteroid_agent.py"]

--- a/agent/asteroid_agent.py
+++ b/agent/asteroid_agent.py
@@ -2,9 +2,9 @@
 message of type `v3.asset.ip.[v4,v6]`, `v3.asset.[domain_name,link]`, or `v3.asset.file.api_schema`, and emits back
 messages of type `v3.report.vulnerability` with a technical report."""
 
+from concurrent import futures
 import ipaddress
 import logging
-from concurrent import futures
 
 from ostorlab.agent import agent
 from ostorlab.agent import definitions as agent_definitions

--- a/agent/definitions.py
+++ b/agent/definitions.py
@@ -1,15 +1,15 @@
 """Agent Asteroid definitions"""
 
 import abc
-import ssl
 import dataclasses
+import ssl
 from typing import Any
 
-import requests
 import cloudscraper
-from packaging import version
 from ostorlab.agent.kb import kb
 from ostorlab.agent.mixins import agent_report_vulnerability_mixin as vuln_mixin
+from packaging import version
+import requests
 
 from agent.exploits import common
 

--- a/agent/exploits/common.py
+++ b/agent/exploits/common.py
@@ -190,8 +190,8 @@ def sort_dict(d: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
     if isinstance(d, list):
         return sorted(
             d,
-            key=lambda x: json.dumps(x, sort_keys=True)
-            if isinstance(x, dict)
-            else str(x),
+            key=lambda x: (
+                json.dumps(x, sort_keys=True) if isinstance(x, dict) else str(x)
+            ),
         )
     return d

--- a/agent/exploits/cve_2019_7193.py
+++ b/agent/exploits/cve_2019_7193.py
@@ -80,7 +80,7 @@ class CVE20197193Exploit(definitions.Exploit):
             return []
         if resp.status_code != 200:
             return []
-        access_match = re.search("(?<=encodeURIComponent\\(').*?(?=')", resp.text)
+        access_match = re.search(r"(?<=encodeURIComponent\(').*?(?=')", resp.text)
         if access_match is None:
             return []
         access_code = access_match.group()

--- a/agent/exploits/cve_2023_25280.py
+++ b/agent/exploits/cve_2023_25280.py
@@ -44,7 +44,7 @@ class DLinkDIR820LA1CommandInjectionExploit(webexploit.WebExploit):
         """
         target_endpoint = urlparse.urljoin(target.origin, self.check_request.path)
 
-        payload = {"ccp_act": "pingV4Msg", "ping_addr": "%0aexpr 123 \* 456 \* 789%0a"}
+        payload = {"ccp_act": "pingV4Msg", "ping_addr": r"%0aexpr 123 \* 456 \* 789%0a"}
 
         try:
             resp = self.session.post(

--- a/agent/exploits/cve_2023_50969.py
+++ b/agent/exploits/cve_2023_50969.py
@@ -28,7 +28,7 @@ class CVE202350969Exploit(webexploit.WebExploit):
         headers=BYPASS_HEADERS,
         data=b"qand=notu&cmd=cat+/etc/passwd",
     )
-    accept_pattern = [re.compile("The event ID is: \d+. The incident ID is: .*")]
+    accept_pattern = [re.compile(r"The event ID is: \d+. The incident ID is: .*")]
     match_pattern = [re.compile(r"^(?!.*incident).*$")]
     metadata = definitions.VulnerabilityMetadata(
         title=VULNERABILITY_TITLE,

--- a/agent/exploits/cve_2024_23113.py
+++ b/agent/exploits/cve_2024_23113.py
@@ -1,15 +1,14 @@
 """Agent Asteroid implementation for CVE-2024-23113"""
 
+import asyncio
 import datetime
 import logging
 import re
 import socket
 
-import asyncio
-
-from requests import exceptions as requests_exceptions
 from pysnmp import error as pysnmp_errors
 from pysnmp.hlapi import asyncio as snmp_asyncio
+from requests import exceptions as requests_exceptions
 
 from agent import definitions
 from agent import exploits_registry

--- a/agent/exploits/cve_2024_23113.py
+++ b/agent/exploits/cve_2024_23113.py
@@ -122,10 +122,10 @@ def _get_fortinet_version_snmp(host: str) -> tuple[str, tuple[int, int, int]] | 
         )
     )
 
-    if error_indication is not None:
+    if error_indication:
         logging.error("SNMP error_indication:: %s", error_indication)
         return None
-    elif error_status is not None:
+    elif error_status:
         logging.error("SNMP error_status: %s at %s", error_status, error_index)
         return None
     else:

--- a/agent/exploits/cve_2024_23113.py
+++ b/agent/exploits/cve_2024_23113.py
@@ -9,15 +9,7 @@ import asyncio
 
 from requests import exceptions as requests_exceptions
 from pysnmp import error as pysnmp_errors
-from pysnmp.hlapi.asyncio import (
-    CommunityData,
-    ContextData,
-    ObjectIdentity,
-    ObjectType,
-    SnmpEngine,
-    UdpTransportTarget,
-    getCmd,
-)
+from pysnmp.hlapi import asyncio as snmp_asyncio
 
 from agent import definitions
 from agent import exploits_registry
@@ -29,7 +21,7 @@ VULNERABILITY_DESCRIPTION = """A use of externally-controlled format string in F
     FortiPAM versions 1.2.0, 1.1.0 through 1.1.2, 1.0.0 through 1.0.3, FortiSwitchManager versions 7.2.0 through 7.2.3, 
     7.0.0 through 7.0.3 allows attacker to execute unauthorized code or commands via specially crafted packets."""
 RISK_RATING = "HIGH"
-DEFAULT_TIMEOUT = TIMEOUT = datetime.timedelta(seconds=10)
+DEFAULT_TIMEOUT = datetime.timedelta(seconds=10)
 REFERENCES = {"fortiguard.com": "https://www.fortiguard.com/psirt/FG-IR-24-029"}
 VULNERABLE_VERSIONS = {
     "FortiOS": [
@@ -115,12 +107,16 @@ def _get_fortinet_version_snmp(host: str) -> tuple[str, tuple[int, int, int]] | 
     product = None
     try:
         error_indication, error_status, error_index, var_binds = asyncio.run(
-            getCmd(
-                SnmpEngine(),
-                CommunityData("public", mpModel=1),
-                UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
-                ContextData(),
-                ObjectType(ObjectIdentity("1.3.6.1.2.1.47.1.1.1.1.10.1")),
+            snmp_asyncio.getCmd(
+                snmp_asyncio.SnmpEngine(),
+                snmp_asyncio.CommunityData("public", mpModel=1),
+                snmp_asyncio.UdpTransportTarget(
+                    (host, 161), timeout=DEFAULT_TIMEOUT.seconds
+                ),
+                snmp_asyncio.ContextData(),
+                snmp_asyncio.ObjectType(
+                    snmp_asyncio.ObjectIdentity("1.3.6.1.2.1.47.1.1.1.1.10.1")
+                ),
             )
         )
     except pysnmp_errors.PySnmpError as e:

--- a/agent/exploits/cve_2024_23113.py
+++ b/agent/exploits/cve_2024_23113.py
@@ -5,8 +5,18 @@ import logging
 import re
 import socket
 
+import asyncio
+
 from requests import exceptions as requests_exceptions
-from pysnmp import hlapi
+from pysnmp.hlapi.asyncio import (
+    CommunityData,
+    ContextData,
+    ObjectIdentity,
+    ObjectType,
+    SnmpEngine,
+    UdpTransportTarget,
+    getCmd,
+)
 
 from agent import definitions
 from agent import exploits_registry
@@ -102,14 +112,15 @@ VULNERABLE_VERSIONS = {
 def _get_fortinet_version_snmp(host: str) -> tuple[str, tuple[int, int, int]] | None:
     version = None
     product = None
-    iterator = hlapi.getCmd(
-        hlapi.SnmpEngine(),
-        hlapi.CommunityData("public", mpModel=1),
-        hlapi.UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
-        hlapi.ContextData(),
-        hlapi.ObjectType(hlapi.ObjectIdentity("1.3.6.1.2.1.47.1.1.1.1.10.1")),
+    error_indication, error_status, error_index, var_binds = asyncio.run(
+        getCmd(
+            SnmpEngine(),
+            CommunityData("public", mpModel=1),
+            UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
+            ContextData(),
+            ObjectType(ObjectIdentity("1.3.6.1.2.1.47.1.1.1.1.10.1")),
+        )
     )
-    error_indication, error_status, error_index, var_binds = next(iterator)
 
     if error_indication is not None:
         logging.error("SNMP error_indication:: %s", error_indication)

--- a/agent/exploits/cve_2024_23113.py
+++ b/agent/exploits/cve_2024_23113.py
@@ -8,6 +8,7 @@ import socket
 import asyncio
 
 from requests import exceptions as requests_exceptions
+from pysnmp import error as pysnmp_errors
 from pysnmp.hlapi.asyncio import (
     CommunityData,
     ContextData,
@@ -112,20 +113,24 @@ VULNERABLE_VERSIONS = {
 def _get_fortinet_version_snmp(host: str) -> tuple[str, tuple[int, int, int]] | None:
     version = None
     product = None
-    error_indication, error_status, error_index, var_binds = asyncio.run(
-        getCmd(
-            SnmpEngine(),
-            CommunityData("public", mpModel=1),
-            UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
-            ContextData(),
-            ObjectType(ObjectIdentity("1.3.6.1.2.1.47.1.1.1.1.10.1")),
+    try:
+        error_indication, error_status, error_index, var_binds = asyncio.run(
+            getCmd(
+                SnmpEngine(),
+                CommunityData("public", mpModel=1),
+                UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
+                ContextData(),
+                ObjectType(ObjectIdentity("1.3.6.1.2.1.47.1.1.1.1.10.1")),
+            )
         )
-    )
+    except pysnmp_errors.PySnmpError as e:
+        logging.error("SNMP error occurred: %s", e)
+        return None
 
-    if error_indication:
+    if error_indication is not None:
         logging.error("SNMP error_indication:: %s", error_indication)
         return None
-    elif error_status:
+    elif error_status != 0:
         logging.error("SNMP error_status: %s at %s", error_status, error_index)
         return None
     else:

--- a/agent/exploits/cve_2024_2879.py
+++ b/agent/exploits/cve_2024_2879.py
@@ -23,7 +23,7 @@ class CVE20242879Exploit(webexploit.WebExploit):
     check_request = definitions.Request(method="GET", path="/")
     accept_pattern = [re.compile("/wp-content/plugins/LayerSlider/")]
     match_pattern = [
-        re.compile("layerslider\/css\/layerslider.css\?ver=(7.9.11|7.10.0)")
+        re.compile(r"layerslider\/css\/layerslider.css\?ver=(7.9.11|7.10.0)")
     ]
     metadata = definitions.VulnerabilityMetadata(
         title=VULNERABILITY_TITLE,

--- a/agent/exploits/cve_2024_29269.py
+++ b/agent/exploits/cve_2024_29269.py
@@ -27,7 +27,7 @@ class CVE202429269Exploit(webexploit.WebExploit):
     )
     accept_pattern = [re.compile("TLR-2005KSH")]
     match_pattern = [
-        re.compile("<CmdResult><!\[CDATA\[systemutil.cgi\n\]\]></CmdResult>")
+        re.compile("<CmdResult><!\\[CDATA\\[systemutil.cgi\n\\]\\]></CmdResult>")
     ]
     metadata = definitions.VulnerabilityMetadata(
         title=VULNERABILITY_TITLE,

--- a/agent/exploits/cve_2024_29269.py
+++ b/agent/exploits/cve_2024_29269.py
@@ -27,7 +27,7 @@ class CVE202429269Exploit(webexploit.WebExploit):
     )
     accept_pattern = [re.compile("TLR-2005KSH")]
     match_pattern = [
-        re.compile("<CmdResult><!\\[CDATA\\[systemutil.cgi\n\\]\\]></CmdResult>")
+        re.compile(r"<CmdResult><!\[CDATA\[systemutil.cgi\n\]\]></CmdResult>")
     ]
     metadata = definitions.VulnerabilityMetadata(
         title=VULNERABILITY_TITLE,

--- a/agent/exploits/cve_2024_39717.py
+++ b/agent/exploits/cve_2024_39717.py
@@ -24,7 +24,7 @@ class CVE202439717Exploit(webexploit.WebExploit):
     accept_request = definitions.Request(method="GET", path="/versa/login")
     check_request = definitions.Request(method="GET", path="/versa/login")
     accept_pattern = [re.compile("Versa Director")]
-    match_pattern = [re.compile("20([0-1][0-9]|2[0-3])\s*Versa Networks")]
+    match_pattern = [re.compile(r"20([0-1][0-9]|2[0-3])\s*Versa Networks")]
 
     metadata = definitions.VulnerabilityMetadata(
         title=VULNERABILITY_TITLE,

--- a/agent/exploits/cve_2024_40766.py
+++ b/agent/exploits/cve_2024_40766.py
@@ -55,9 +55,9 @@ def _get_sonicwall_version(host: str) -> str | None:
     except pysnmp_errors.PySnmpError:
         return None
 
-    if error_indication is True:
+    if error_indication:
         logging.error("error_indication: %s", error_indication)
-    elif error_status is True:
+    elif error_status:
         logging.error("error_status: %s at %s", error_status, error_index)
     else:
         for var_bind in var_binds:

--- a/agent/exploits/cve_2024_40766.py
+++ b/agent/exploits/cve_2024_40766.py
@@ -1,9 +1,8 @@
 """Agent Asteroid implementation for CVE-2024-40766"""
 
+import asyncio
 import logging
 import re
-
-import asyncio
 
 from pysnmp import error as pysnmp_errors
 from pysnmp.hlapi import asyncio as snmp_asyncio

--- a/agent/exploits/cve_2024_40766.py
+++ b/agent/exploits/cve_2024_40766.py
@@ -6,15 +6,7 @@ import re
 import asyncio
 
 from pysnmp import error as pysnmp_errors
-from pysnmp.hlapi.asyncio import (
-    CommunityData,
-    ContextData,
-    ObjectIdentity,
-    ObjectType,
-    SnmpEngine,
-    UdpTransportTarget,
-    getCmd,
-)
+from pysnmp.hlapi import asyncio as snmp_asyncio
 
 from agent import definitions
 from agent import exploits_registry
@@ -44,12 +36,14 @@ def _get_sonicwall_version(host: str) -> str | None:
     version = None
     try:
         error_indication, error_status, error_index, var_binds = asyncio.run(
-            getCmd(
-                SnmpEngine(),
-                CommunityData("public", mpModel=1),
-                UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT),
-                ContextData(),
-                ObjectType(ObjectIdentity("1.3.6.1.2.1.1.1.0")),
+            snmp_asyncio.getCmd(
+                snmp_asyncio.SnmpEngine(),
+                snmp_asyncio.CommunityData("public", mpModel=1),
+                snmp_asyncio.UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT),
+                snmp_asyncio.ContextData(),
+                snmp_asyncio.ObjectType(
+                    snmp_asyncio.ObjectIdentity("1.3.6.1.2.1.1.1.0")
+                ),
             )
         )
     except pysnmp_errors.PySnmpError as e:

--- a/agent/exploits/cve_2024_40766.py
+++ b/agent/exploits/cve_2024_40766.py
@@ -3,8 +3,19 @@
 import logging
 import re
 
-from pysnmp import hlapi
+import asyncio
+
 from pysnmp import error as pysnmp_errors
+from pysnmp.hlapi.asyncio import (
+    CommunityData,
+    ContextData,
+    ObjectIdentity,
+    ObjectType,
+    SnmpEngine,
+    UdpTransportTarget,
+    getCmd,
+)
+
 from agent import definitions
 from agent import exploits_registry
 
@@ -32,16 +43,17 @@ VULNERABLE_VERSIONS = [
 def _get_sonicwall_version(host: str) -> str | None:
     version = None
     try:
-        iterator = hlapi.getCmd(
-            hlapi.SnmpEngine(),
-            hlapi.CommunityData("public", mpModel=1),
-            hlapi.UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT),
-            hlapi.ContextData(),
-            hlapi.ObjectType(hlapi.ObjectIdentity("1.3.6.1.2.1.1.1.0")),  # sysDescr OID
+        error_indication, error_status, error_index, var_binds = asyncio.run(
+            getCmd(
+                SnmpEngine(),
+                CommunityData("public", mpModel=1),
+                UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT),
+                ContextData(),
+                ObjectType(ObjectIdentity("1.3.6.1.2.1.1.1.0")),
+            )
         )
     except pysnmp_errors.PySnmpError:
         return None
-    error_indication, error_status, error_index, var_binds = next(iterator)
 
     if error_indication is True:
         logging.error("error_indication: %s", error_indication)

--- a/agent/exploits/cve_2024_40766.py
+++ b/agent/exploits/cve_2024_40766.py
@@ -52,12 +52,13 @@ def _get_sonicwall_version(host: str) -> str | None:
                 ObjectType(ObjectIdentity("1.3.6.1.2.1.1.1.0")),
             )
         )
-    except pysnmp_errors.PySnmpError:
+    except pysnmp_errors.PySnmpError as e:
+        logging.error("SNMP error occurred: %s", e)
         return None
 
-    if error_indication:
+    if error_indication is not None:
         logging.error("error_indication: %s", error_indication)
-    elif error_status:
+    elif error_status != 0:
         logging.error("error_status: %s at %s", error_status, error_index)
     else:
         for var_bind in var_binds:

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -94,9 +94,9 @@ def _get_aruba_version(host: str) -> str | None:
         )
     )
 
-    if error_indication is True:
+    if error_indication:
         logging.error("SNMP error_indication: %s", error_indication)
-    elif error_status is True:
+    elif error_status:
         logging.error("SNMP error_status: %s at %s", error_status, error_index)
     else:
         for var_bind in var_binds:

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -4,8 +4,18 @@ import logging
 import re
 import datetime
 
-from pysnmp import hlapi
+import asyncio
+
 from packaging import version as ver
+from pysnmp.hlapi.asyncio import (
+    CommunityData,
+    ContextData,
+    ObjectIdentity,
+    ObjectType,
+    SnmpEngine,
+    UdpTransportTarget,
+    getCmd,
+)
 
 from agent import definitions
 from agent import exploits_registry
@@ -74,14 +84,15 @@ def _is_version_vulnerable(version: str) -> bool:
 def _get_aruba_version(host: str) -> str | None:
     """Send SNMP request to retrieve the system description."""
     version = None
-    iterator = hlapi.getCmd(
-        hlapi.SnmpEngine(),
-        hlapi.CommunityData("public", mpModel=1),
-        hlapi.UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
-        hlapi.ContextData(),
-        hlapi.ObjectType(hlapi.ObjectIdentity(OID)),  # sysDescr OID
+    error_indication, error_status, error_index, var_binds = asyncio.run(
+        getCmd(
+            SnmpEngine(),
+            CommunityData("public", mpModel=1),
+            UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
+            ContextData(),
+            ObjectType(ObjectIdentity(OID)),
+        )
     )
-    error_indication, error_status, error_index, var_binds = next(iterator)
 
     if error_indication is True:
         logging.error("SNMP error_indication: %s", error_indication)

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -7,6 +7,7 @@ import datetime
 import asyncio
 
 from packaging import version as ver
+from pysnmp import error as pysnmp_errors
 from pysnmp.hlapi.asyncio import (
     CommunityData,
     ContextData,
@@ -84,19 +85,23 @@ def _is_version_vulnerable(version: str) -> bool:
 def _get_aruba_version(host: str) -> str | None:
     """Send SNMP request to retrieve the system description."""
     version = None
-    error_indication, error_status, error_index, var_binds = asyncio.run(
-        getCmd(
-            SnmpEngine(),
-            CommunityData("public", mpModel=1),
-            UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
-            ContextData(),
-            ObjectType(ObjectIdentity(OID)),
+    try:
+        error_indication, error_status, error_index, var_binds = asyncio.run(
+            getCmd(
+                SnmpEngine(),
+                CommunityData("public", mpModel=1),
+                UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
+                ContextData(),
+                ObjectType(ObjectIdentity(OID)),
+            )
         )
-    )
+    except pysnmp_errors.PySnmpError as e:
+        logging.error("SNMP error occurred: %s", e)
+        return None
 
-    if error_indication:
+    if error_indication is not None:
         logging.error("SNMP error_indication: %s", error_indication)
-    elif error_status:
+    elif error_status != 0:
         logging.error("SNMP error_status: %s at %s", error_status, error_index)
     else:
         for var_bind in var_binds:

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -8,15 +8,7 @@ import asyncio
 
 from packaging import version as ver
 from pysnmp import error as pysnmp_errors
-from pysnmp.hlapi.asyncio import (
-    CommunityData,
-    ContextData,
-    ObjectIdentity,
-    ObjectType,
-    SnmpEngine,
-    UdpTransportTarget,
-    getCmd,
-)
+from pysnmp.hlapi import asyncio as snmp_asyncio
 
 from agent import definitions
 from agent import exploits_registry
@@ -87,12 +79,14 @@ def _get_aruba_version(host: str) -> str | None:
     version = None
     try:
         error_indication, error_status, error_index, var_binds = asyncio.run(
-            getCmd(
-                SnmpEngine(),
-                CommunityData("public", mpModel=1),
-                UdpTransportTarget((host, 161), timeout=DEFAULT_TIMEOUT.seconds),
-                ContextData(),
-                ObjectType(ObjectIdentity(OID)),
+            snmp_asyncio.getCmd(
+                snmp_asyncio.SnmpEngine(),
+                snmp_asyncio.CommunityData("public", mpModel=1),
+                snmp_asyncio.UdpTransportTarget(
+                    (host, 161), timeout=DEFAULT_TIMEOUT.seconds
+                ),
+                snmp_asyncio.ContextData(),
+                snmp_asyncio.ObjectType(snmp_asyncio.ObjectIdentity(OID)),
             )
         )
     except pysnmp_errors.PySnmpError as e:

--- a/agent/exploits/cve_2024_42509.py
+++ b/agent/exploits/cve_2024_42509.py
@@ -1,10 +1,9 @@
 """Agent Asteroid implementation for CVE-2024-42509"""
 
+import asyncio
+import datetime
 import logging
 import re
-import datetime
-
-import asyncio
 
 from packaging import version as ver
 from pysnmp import error as pysnmp_errors

--- a/agent/exploits/cve_2024_43044.py
+++ b/agent/exploits/cve_2024_43044.py
@@ -27,7 +27,7 @@ DEFAULT_TIMEOUT = 90
 class CVE202443044Exploit(webexploit.WebExploit):
     accept_request = definitions.Request(method="GET", path="/")
     check_request = definitions.Request(method="GET", path="/")
-    accept_pattern = [re.compile("Sign in \[Jenkins\]")]
+    accept_pattern = [re.compile(r"Sign in \[Jenkins\]")]
     metadata = definitions.VulnerabilityMetadata(
         title=VULNERABILITY_TITLE,
         description=VULNERABILITY_DESCRIPTION,

--- a/agent/exploits/cve_2024_5315.py
+++ b/agent/exploits/cve_2024_5315.py
@@ -28,7 +28,7 @@ class CVE20245315Exploit(webexploit.WebExploit):
 
     accept_request = definitions.Request(method="GET", path="/")
     check_request = definitions.Request(method="GET", path="/")
-    accept_pattern = [re.compile("<title>(Identifiant|Login) @ \d+\.\d+\.\d+</title>")]
+    accept_pattern = [re.compile(r"<title>(Identifiant|Login) @ \d+\.\d+\.\d+</title>")]
     vuln_ranges = [definitions.VulnRange(None, MAX_VULNERABLE_VERSION)]
     metadata = definitions.VulnerabilityMetadata(
         title=VULNERABILITY_TITLE,

--- a/agent/exploits/cve_2024_54134.py
+++ b/agent/exploits/cve_2024_54134.py
@@ -22,7 +22,7 @@ VERSION_PATTERN = re.compile(r"@solana/web3\.js@(\d+\.\d+\.\d+)")
 class CVE202454134Exploit(webexploit.WebExploit):
     accept_request = definitions.Request(method="GET", path="/")
     check_request = definitions.Request(method="GET", path="/")
-    accept_pattern = [re.compile("https://unpkg\.com/@solana/web3\.js")]
+    accept_pattern = [re.compile(r"https://unpkg\.com/@solana/web3\.js")]
     vuln_ranges = [
         definitions.VulnRange(MIN_VULNERABLE_VERSION, MAX_VULNERABLE_VERSION)
     ]

--- a/agent/exploits/cve_2024_9487.py
+++ b/agent/exploits/cve_2024_9487.py
@@ -31,8 +31,8 @@ VULNERABLE_RANGES = [
 class CVE20249487Exploit(webexploit.WebExploit):
     accept_request = definitions.Request(method="GET", path="/")
     check_request = definitions.Request(method="GET", path="/")
-    accept_pattern = [re.compile("GitHub\sEnterprise\sServer\s\d+\.\d+\.\d+")]
-    version_pattern = re.compile("GitHub\sEnterprise\sServer\s(\d+\.\d+\.\d+)")
+    accept_pattern = [re.compile(r"GitHub\sEnterprise\sServer\s\d+\.\d+\.\d+")]
+    version_pattern = re.compile(r"GitHub\sEnterprise\sServer\s(\d+\.\d+\.\d+)")
 
     metadata = definitions.VulnerabilityMetadata(
         title=VULNERABILITY_TITLE,

--- a/agent/exploits/cve_2025_4322.py
+++ b/agent/exploits/cve_2025_4322.py
@@ -76,7 +76,7 @@ def _check_homepage_for_motors_form_indicator(
         )
         if (
             response.status_code == 200
-            and re.search("Theme Name:\s*Motors", response.text) is not None
+            and re.search(r"Theme Name:\s*Motors", response.text) is not None
         ):
             logger.info(
                 "Found Motors form indicator '%s' at homepage %s",

--- a/agent/exploits/cve_2025_4322.py
+++ b/agent/exploits/cve_2025_4322.py
@@ -1,10 +1,11 @@
 """Agent implementation for detecting CVE-2025-4322."""
 
 import datetime
-import re
 import logging
-from requests import exceptions as requests_exceptions
+import re
 from urllib.parse import urljoin
+
+from requests import exceptions as requests_exceptions
 
 from agent import definitions
 from agent import exploits_registry

--- a/agent/exploits/jetpack_version_detection.py
+++ b/agent/exploits/jetpack_version_detection.py
@@ -139,7 +139,7 @@ class JetpackExploit(webexploit.WebExploit):
     accept_pattern = [
         re.compile("=== Jetpack - WP Security, Backup, Speed, & Growth ===")
     ]
-    version_pattern = re.compile("Stable\stag:\s(\d+\.\d+\.\d+)")
+    version_pattern = re.compile(r"Stable\stag:\s(\d+\.\d+\.\d+)")
 
     metadata = definitions.VulnerabilityMetadata(
         title=VULNERABILITY_TITLE,

--- a/agent/exploits/jetpack_version_detection.py
+++ b/agent/exploits/jetpack_version_detection.py
@@ -193,7 +193,7 @@ def _is_vulnerable(extracted_version: str) -> bool:
     extracted_ver = semver.Version.parse(extracted_version)
 
     for min_version, max_version in VULNERABLE_RANGES:
-        min_ver = semver.Version.parse(min_version) if min_version else None
+        min_ver = semver.Version.parse(min_version) if min_version is not None else None
         max_ver = semver.Version.parse(max_version)
 
         if (min_ver is None or extracted_ver >= min_ver) and extracted_ver <= max_ver:

--- a/agent/exploits/webexploit.py
+++ b/agent/exploits/webexploit.py
@@ -1,10 +1,10 @@
 import re
-import urllib3
 from urllib import parse as urlparse
 
+from packaging import version
 import requests
 from requests import exceptions as requests_exceptions
-from packaging import version
+import urllib3
 
 from agent import definitions
 

--- a/agent/importer.py
+++ b/agent/importer.py
@@ -1,5 +1,6 @@
 """Dynamic importer to enable registry pattern."""
 
+import importlib
 import logging
 import sys
 import traceback
@@ -14,12 +15,15 @@ def importer_for(path: str, prefix: str) -> Callable[[], None]:
     """
     Creates a function for importing all Python files in a specified folder and adding them as attributes
     to a given module.
+
     Args:
         path (str): the path to the folder containing the Python files to import
         prefix (str): the prefix to use when adding the imported files as attributes to the module
+
     Returns:
         A function that can be called to perform the import and attribute assignment. The function takes two
         optional arguments:
+
         - file_path (str): the path to the folder containing the Python files to import (default is `path`)
         - stop_on_error (bool): whether to stop execution if an error occurs during import (default is `True`)
     """
@@ -27,6 +31,7 @@ def importer_for(path: str, prefix: str) -> Callable[[], None]:
     def import_all(path: str = path, stop_on_error: bool = True) -> None:
         """
         Imports all Python files in a specified folder and adds them as attributes to a given module.
+
         Args:
             file_path (str): the path to the folder containing the Python files to import
              (default is the value passed to `importer_for`)
@@ -34,20 +39,25 @@ def importer_for(path: str, prefix: str) -> Callable[[], None]:
         """
         folder = os.path.dirname(path)
         module = sys.modules[prefix]
-        for importer, name, _ in pkgutil.iter_modules([folder]):
+
+        for _, name, _ in pkgutil.iter_modules([folder]):
             absname = prefix + "." + name
+
             if absname in sys.modules:
                 continue
-            loader = importer.find_module(absname)  # type: ignore
+
             try:
-                if loader is not None:
-                    submod = loader.load_module(absname)
+                submod = importlib.import_module(absname)
             except ImportError as e:
                 if stop_on_error:
                     raise
                 # This is for debugging to print the full trace and pinpoint to source of the exception.
                 traceback.print_exc()
-                logger.warning("Cannot load REbus plugin [%s]. Root cause: %s", name, e)
+                logger.warning(
+                    "Cannot load REbus plugin [%s]. Root cause: %s",
+                    name,
+                    e,
+                )
             else:
                 setattr(module, name, submod)
 

--- a/agent/importer.py
+++ b/agent/importer.py
@@ -49,7 +49,7 @@ def importer_for(path: str, prefix: str) -> Callable[[], None]:
             try:
                 submod = importlib.import_module(absname)
             except ImportError as e:
-                if stop_on_error:
+                if stop_on_error is True:
                     raise
                 # This is for debugging to print the full trace and pinpoint to source of the exception.
                 traceback.print_exc()

--- a/agent/targets_preparer.py
+++ b/agent/targets_preparer.py
@@ -1,11 +1,12 @@
 """Target Preparer Module for Asteroid Agent"""
 
+import ipaddress
+import logging
 from typing import Generator
 from urllib.parse import urlparse
-import logging
 
 from ostorlab.agent.message import message as m
-import ipaddress
+
 from agent import definitions
 
 logger = logging.getLogger(__name__)

--- a/requirement.txt
+++ b/requirement.txt
@@ -7,10 +7,10 @@ packaging
 pygments
 semantic_version
 impacket
-pysnmp==4.4.6
+pysnmp>=6.2.6
 pyasn1==0.6.0
 jaydebeapi
 cloudscraper
-psycopg
+psycopg[binary]
 tld
 pwntools

--- a/requirement.txt
+++ b/requirement.txt
@@ -7,7 +7,7 @@ packaging
 pygments
 semantic_version
 impacket
-pysnmp>=6.2.6
+pysnmp>=6.2.6,<7.0.0
 pyasn1==0.6.0
 jaydebeapi
 cloudscraper

--- a/tests/exploits/cve_2024_23113_test.py
+++ b/tests/exploits/cve_2024_23113_test.py
@@ -22,7 +22,7 @@ def testCVE202423113_whenVulnerable_reportFinding(
     )
 
     mocker.patch(
-        "agent.exploits.cve_2024_23113.getCmd",
+        "agent.exploits.cve_2024_23113.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
@@ -59,7 +59,7 @@ def testCVE202423113_whenSafe_reportNothing(
     )
 
     mocker.patch(
-        "agent.exploits.cve_2024_23113.getCmd",
+        "agent.exploits.cve_2024_23113.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
@@ -85,7 +85,7 @@ def testCVE202423113_whenVersionNotFound_reportNothing(
     )
 
     mocker.patch(
-        "agent.exploits.cve_2024_23113.getCmd",
+        "agent.exploits.cve_2024_23113.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
@@ -106,7 +106,7 @@ def testCVE202423113_whenSNMPErrorStatus_handleGracefully(
     """CVE-2024-23113 unit test: case when SNMP returns an error status."""
 
     mocker.patch(
-        "agent.exploits.cve_2024_23113.getCmd",
+        "agent.exploits.cve_2024_23113.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, "Error", 0, None)),
     )
     mock_logging = mocker.patch("logging.error")
@@ -137,7 +137,7 @@ def testCVE202423113_whenSNMPFails_fallbackToOtherMethods(
 
     # Mock SNMP to fail
     mocker.patch(
-        "agent.exploits.cve_2024_23113.getCmd",
+        "agent.exploits.cve_2024_23113.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=("Error", None, None, None)),
     )
 

--- a/tests/exploits/cve_2024_23113_test.py
+++ b/tests/exploits/cve_2024_23113_test.py
@@ -23,7 +23,7 @@ def testCVE202423113_whenVulnerable_reportFinding(
 
     mocker.patch(
         "agent.exploits.cve_2024_23113.getCmd",
-        new=mock.AsyncMock(return_value=(None, None, None, [mock_var_bind])),
+        new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
     exploit_instance = cve_2024_23113.CVE202423113Exploit()
@@ -60,7 +60,7 @@ def testCVE202423113_whenSafe_reportNothing(
 
     mocker.patch(
         "agent.exploits.cve_2024_23113.getCmd",
-        new=mock.AsyncMock(return_value=(None, None, None, [mock_var_bind])),
+        new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
     exploit_instance = cve_2024_23113.CVE202423113Exploit()
@@ -86,7 +86,7 @@ def testCVE202423113_whenVersionNotFound_reportNothing(
 
     mocker.patch(
         "agent.exploits.cve_2024_23113.getCmd",
-        new=mock.AsyncMock(return_value=(None, None, None, [mock_var_bind])),
+        new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
     exploit_instance = cve_2024_23113.CVE202423113Exploit()

--- a/tests/exploits/cve_2024_23113_test.py
+++ b/tests/exploits/cve_2024_23113_test.py
@@ -21,9 +21,10 @@ def testCVE202423113_whenVulnerable_reportFinding(
         f"FortiOS v{vulnerable_version}"
     )
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (None, None, None, [mock_var_bind])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_23113.getCmd",
+        new=mock.AsyncMock(return_value=(None, None, None, [mock_var_bind])),
+    )
 
     exploit_instance = cve_2024_23113.CVE202423113Exploit()
 
@@ -57,9 +58,10 @@ def testCVE202423113_whenSafe_reportNothing(
         f"FortiOS v{safe_version}"
     )
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (None, None, None, [mock_var_bind])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_23113.getCmd",
+        new=mock.AsyncMock(return_value=(None, None, None, [mock_var_bind])),
+    )
 
     exploit_instance = cve_2024_23113.CVE202423113Exploit()
 
@@ -82,9 +84,10 @@ def testCVE202423113_whenVersionNotFound_reportNothing(
         "Unexpected response"
     )
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (None, None, None, [mock_var_bind])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_23113.getCmd",
+        new=mock.AsyncMock(return_value=(None, None, None, [mock_var_bind])),
+    )
 
     exploit_instance = cve_2024_23113.CVE202423113Exploit()
 
@@ -102,9 +105,10 @@ def testCVE202423113_whenSNMPErrorStatus_handleGracefully(
 ) -> None:
     """CVE-2024-23113 unit test: case when SNMP returns an error status."""
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (None, "Error", 0, None)
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_23113.getCmd",
+        new=mock.AsyncMock(return_value=(None, "Error", 0, None)),
+    )
     mock_logging = mocker.patch("logging.error")
 
     mocker.patch(
@@ -132,9 +136,10 @@ def testCVE202423113_whenSNMPFails_fallbackToOtherMethods(
     """CVE-2024-23113 unit test: case when SNMP fails and falls back to other methods."""
 
     # Mock SNMP to fail
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = ("Error", None, None, None)
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_23113.getCmd",
+        new=mock.AsyncMock(return_value=("Error", None, None, None)),
+    )
 
     # Mock HTTP detection to succeed
     mocker.patch(

--- a/tests/exploits/cve_2024_40766_test.py
+++ b/tests/exploits/cve_2024_40766_test.py
@@ -21,7 +21,7 @@ def testCVE202440766_whenVulnerable_reportFinding(
     )
 
     mocker.patch(
-        "agent.exploits.cve_2024_40766.getCmd",
+        "agent.exploits.cve_2024_40766.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
@@ -57,7 +57,7 @@ def testCVE202440766_whenSafe_reportNothing(
     )
 
     mocker.patch(
-        "agent.exploits.cve_2024_40766.getCmd",
+        "agent.exploits.cve_2024_40766.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
@@ -83,7 +83,7 @@ def testCVE202440766_whenVersionNotFound_reportNothing(
     )
 
     mocker.patch(
-        "agent.exploits.cve_2024_40766.getCmd",
+        "agent.exploits.cve_2024_40766.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
@@ -104,7 +104,7 @@ def testCVE202440766_whenSNMPError_handleGracefully(
     """CVE-2024-40766 unit test: case when SNMP returns an error."""
 
     mocker.patch(
-        "agent.exploits.cve_2024_40766.getCmd",
+        "agent.exploits.cve_2024_40766.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(True, False, False, [])),
     )
     mock_logging = mocker.patch("logging.error")
@@ -126,7 +126,7 @@ def testCVE202440766_whenPySnmpErrorRaise_handleGracefully(
 ) -> None:
     """Ensure CVE-2024-40766 exploit handles PySnmpError raised by hlapi.getCmd."""
     mocker.patch(
-        "agent.exploits.cve_2024_40766.getCmd",
+        "agent.exploits.cve_2024_40766.snmp_asyncio.getCmd",
         new=mock.AsyncMock(side_effect=pysnmp_errors.PySnmpError),
     )
     exploit_instance = cve_2024_40766.CVE202440766Exploit()

--- a/tests/exploits/cve_2024_40766_test.py
+++ b/tests/exploits/cve_2024_40766_test.py
@@ -22,7 +22,7 @@ def testCVE202440766_whenVulnerable_reportFinding(
 
     mocker.patch(
         "agent.exploits.cve_2024_40766.getCmd",
-        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+        new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
     exploit_instance = cve_2024_40766.CVE202440766Exploit()
@@ -58,7 +58,7 @@ def testCVE202440766_whenSafe_reportNothing(
 
     mocker.patch(
         "agent.exploits.cve_2024_40766.getCmd",
-        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+        new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
     exploit_instance = cve_2024_40766.CVE202440766Exploit()
@@ -84,7 +84,7 @@ def testCVE202440766_whenVersionNotFound_reportNothing(
 
     mocker.patch(
         "agent.exploits.cve_2024_40766.getCmd",
-        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+        new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
     exploit_instance = cve_2024_40766.CVE202440766Exploit()

--- a/tests/exploits/cve_2024_40766_test.py
+++ b/tests/exploits/cve_2024_40766_test.py
@@ -20,9 +20,10 @@ def testCVE202440766_whenVulnerable_reportFinding(
         f"SonicOS Enhanced {vulnerable_version}"
     )
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (False, False, False, [mock_var_bind])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_40766.getCmd",
+        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+    )
 
     exploit_instance = cve_2024_40766.CVE202440766Exploit()
 
@@ -55,9 +56,10 @@ def testCVE202440766_whenSafe_reportNothing(
         f"SonicOS Enhanced {safe_version}"
     )
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (False, False, False, [mock_var_bind])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_40766.getCmd",
+        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+    )
 
     exploit_instance = cve_2024_40766.CVE202440766Exploit()
 
@@ -80,9 +82,10 @@ def testCVE202440766_whenVersionNotFound_reportNothing(
         "Unexpected response"
     )
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (False, False, False, [mock_var_bind])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_40766.getCmd",
+        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+    )
 
     exploit_instance = cve_2024_40766.CVE202440766Exploit()
 
@@ -100,9 +103,10 @@ def testCVE202440766_whenSNMPError_handleGracefully(
 ) -> None:
     """CVE-2024-40766 unit test: case when SNMP returns an error."""
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (True, False, False, [])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_40766.getCmd",
+        new=mock.AsyncMock(return_value=(True, False, False, [])),
+    )
     mock_logging = mocker.patch("logging.error")
 
     exploit_instance = cve_2024_40766.CVE202440766Exploit()
@@ -121,7 +125,10 @@ def testCVE202440766_whenPySnmpErrorRaise_handleGracefully(
     mocker: plugin.MockerFixture,
 ) -> None:
     """Ensure CVE-2024-40766 exploit handles PySnmpError raised by hlapi.getCmd."""
-    mocker.patch("pysnmp.hlapi.getCmd", side_effect=pysnmp_errors.PySnmpError)
+    mocker.patch(
+        "agent.exploits.cve_2024_40766.getCmd",
+        new=mock.AsyncMock(side_effect=pysnmp_errors.PySnmpError),
+    )
     exploit_instance = cve_2024_40766.CVE202440766Exploit()
     target = definitions.Target("udp", "192.168.1.1", 161)
 

--- a/tests/exploits/cve_2024_42509_test.py
+++ b/tests/exploits/cve_2024_42509_test.py
@@ -17,9 +17,10 @@ def testCVE202442509_whenVulnerable_reportFinding(mocker: plugin.MockerFixture) 
         f"ArubaOS (MODEL: AP-325), Version {vulnerable_version}"
     )
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (False, False, False, [mock_var_bind])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_42509.getCmd",
+        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+    )
 
     exploit_instance = cve_2024_42509.CVE202442509Exploit()
 
@@ -50,9 +51,10 @@ def testCVE202442509_whenSafe_reportNothing(mocker: plugin.MockerFixture) -> Non
         f"ArubaOS (MODEL: AP-325), Version {safe_version}"
     )
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (False, False, False, [mock_var_bind])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_42509.getCmd",
+        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+    )
 
     exploit_instance = cve_2024_42509.CVE202442509Exploit()
 
@@ -75,9 +77,10 @@ def testCVE202442509_whenVersionNotFound_reportNothing(
         "Unexpected response"
     )
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (False, False, False, [mock_var_bind])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_42509.getCmd",
+        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+    )
 
     exploit_instance = cve_2024_42509.CVE202442509Exploit()
 
@@ -95,9 +98,10 @@ def testCVE202442509_whenSNMPError_handleGracefully(
 ) -> None:
     """CVE-2024-42509 unit test: case when SNMP returns an error."""
 
-    mock_iterator = mock.MagicMock()
-    mock_iterator.__next__.return_value = (True, False, False, [])
-    mocker.patch("pysnmp.hlapi.getCmd", return_value=mock_iterator)
+    mocker.patch(
+        "agent.exploits.cve_2024_42509.getCmd",
+        new=mock.AsyncMock(return_value=(True, False, False, [])),
+    )
     mock_logging = mocker.patch("logging.error")
 
     exploit_instance = cve_2024_42509.CVE202442509Exploit()

--- a/tests/exploits/cve_2024_42509_test.py
+++ b/tests/exploits/cve_2024_42509_test.py
@@ -19,7 +19,7 @@ def testCVE202442509_whenVulnerable_reportFinding(mocker: plugin.MockerFixture) 
 
     mocker.patch(
         "agent.exploits.cve_2024_42509.getCmd",
-        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+        new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
     exploit_instance = cve_2024_42509.CVE202442509Exploit()
@@ -53,7 +53,7 @@ def testCVE202442509_whenSafe_reportNothing(mocker: plugin.MockerFixture) -> Non
 
     mocker.patch(
         "agent.exploits.cve_2024_42509.getCmd",
-        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+        new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
     exploit_instance = cve_2024_42509.CVE202442509Exploit()
@@ -79,7 +79,7 @@ def testCVE202442509_whenVersionNotFound_reportNothing(
 
     mocker.patch(
         "agent.exploits.cve_2024_42509.getCmd",
-        new=mock.AsyncMock(return_value=(False, False, False, [mock_var_bind])),
+        new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
     exploit_instance = cve_2024_42509.CVE202442509Exploit()

--- a/tests/exploits/cve_2024_42509_test.py
+++ b/tests/exploits/cve_2024_42509_test.py
@@ -18,7 +18,7 @@ def testCVE202442509_whenVulnerable_reportFinding(mocker: plugin.MockerFixture) 
     )
 
     mocker.patch(
-        "agent.exploits.cve_2024_42509.getCmd",
+        "agent.exploits.cve_2024_42509.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
@@ -52,7 +52,7 @@ def testCVE202442509_whenSafe_reportNothing(mocker: plugin.MockerFixture) -> Non
     )
 
     mocker.patch(
-        "agent.exploits.cve_2024_42509.getCmd",
+        "agent.exploits.cve_2024_42509.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
@@ -78,7 +78,7 @@ def testCVE202442509_whenVersionNotFound_reportNothing(
     )
 
     mocker.patch(
-        "agent.exploits.cve_2024_42509.getCmd",
+        "agent.exploits.cve_2024_42509.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(None, 0, 0, [mock_var_bind])),
     )
 
@@ -99,7 +99,7 @@ def testCVE202442509_whenSNMPError_handleGracefully(
     """CVE-2024-42509 unit test: case when SNMP returns an error."""
 
     mocker.patch(
-        "agent.exploits.cve_2024_42509.getCmd",
+        "agent.exploits.cve_2024_42509.snmp_asyncio.getCmd",
         new=mock.AsyncMock(return_value=(True, False, False, [])),
     )
     mock_logging = mocker.patch("logging.error")

--- a/tests/test-requirement.txt
+++ b/tests/test-requirement.txt
@@ -7,4 +7,4 @@ requests_mock
 types-requests
 pytest_mock
 ruff
-psycopg
+psycopg[binary]


### PR DESCRIPTION
## Overview

Upgrades Agent Asteroid from Python 3.11 to Python 3.14. Three compatibility issues had to be resolved.

---

### Issue 1 — pysnmp dropped its synchronous API

**What broke:** The three SNMP-based exploits (`CVE-2024-23113`, `CVE-2024-40766`, `CVE-2024-42509`) used `pysnmp 4.4.6`, which provided a synchronous iterator-based API (`hlapi.getCmd()` returned an iterator, and you called `next()` on it). This API was removed in `pysnmp 6.x`.

**How it was fixed:** Upgraded to `pysnmp>=6.2.6,<7.0.0` and migrated all three exploits to the new async API (`pysnmp.hlapi.asyncio.getCmd`), called via `asyncio.run()` to stay compatible with the synchronous exploit interface.

The test mocks were updated to patch `snmp_asyncio.getCmd` and use `AsyncMock`.

---

### Issue 2 — `pkgutil` loader API removed

**What broke:** `agent/importer.py` used `importer.find_module()` and `loader.load_module()`, a `pkgutil` pattern that was deprecated in Python 3.4 and removed in Python 3.12.

**How it was fixed:** Replaced with `importlib.import_module(absname)`, the modern equivalent. The discovery logic and error handling are otherwise unchanged.

---

### Issue 3 — Invalid escape sequences in regex strings

**What broke:** Many regex patterns were written as plain strings (e.g. `"\d+"`, `"\s"`, `"\["`) rather than raw strings. Python 3.12 made these a `DeprecationWarning` and Python 3.14 raises a `SyntaxWarning` — they would eventually become `SyntaxError`.

**How it was fixed:** All affected patterns were converted to raw strings (`r"\d+"`, `r"\s"`, etc.) across the exploit files. No matching behaviour changed.

---

### Other changes

- **Dockerfile:** Base image updated to `python:3.14-slim`. Build-time dependencies (`g++`, `make`, `cmake`, etc.) moved to the builder stage only. `libffi-dev` added to the runtime stage (required by cffi-based packages on 3.14).
- **`psycopg` → `psycopg[binary]`:** The binary wheel extra is required on Python 3.14 where the C extension cannot compile without additional system libraries.
- **`.dockerignore`:** Added `venv`/`.venv` to prevent local virtual environments from being copied into the image.
- **CI workflows:** Python version bumped to 3.14 in all three workflow files (lint, typing, pytest).


https://github.com/user-attachments/assets/2d84d260-f9d1-4b6c-af27-6402346b5712